### PR TITLE
chore(deps): bump react to 19.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "lucide-react": "^0.561.0",
     "next": "16.0.10",
     "next-mdx-remote": "^5.0.0",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "shiki": "^3.21.0",
     "tailwind-merge": "^3.4.0"
   },


### PR DESCRIPTION
## What changed
- Bump `react` from `^19.2.3` to `^19.2.5`
- Bump `react-dom` from `^19.2.3` to `^19.2.5`

## Current dependency baseline on `main`
From `package.json` on `main` as of 2026-05-04:
- `next`: `16.0.10`
- `@next/mdx`: `^16.0.10`
- `react`: `^19.2.3`
- `react-dom`: `^19.2.3`
- `shiki`: `^3.21.0`
- `tailwindcss`: `^4.1.18`
- `@tailwindcss/postcss`: `^4.1.18`
- `lucide-react`: `^0.561.0`
- `tailwind-merge`: `^3.4.0`
- `typescript`: `^5.9.3`

## Why this is the smallest viable set
`bun outdated` on 2026-05-04 showed several newer packages, but `react` and `react-dom` were the only direct production dependencies with a patch-level update. This keeps the sweep limited to the lowest-risk runtime bump.

## Breaking-change risk / migration notes
- `react` / `react-dom` `19.2.5`: patch release, low risk, no migration expected.
- Held back intentionally:
  - `lucide-react` `0.561.0 -> 1.14.0`: major bump from a `0.x` line; icon/API compatibility should be reviewed before upgrade.
  - `shiki` `3.21.0 -> 4.0.2`: major bump; dedicated migration review needed.
  - `typescript` `5.9.3 -> 6.0.3`: major bump; type-checking/config regressions need a separate pass.
  - `next` `16.0.10 -> 16.2.2`: minor framework bump, but it broadens the sweep beyond the smallest viable set.
  - `tailwindcss` `4.1.18 -> 4.2.4` and `@tailwindcss/postcss` `4.1.18 -> 4.2.2`: minor toolchain updates, deferred to avoid wider CSS/build churn.
  - `tailwind-merge` `3.4.0 -> 3.5.0`: minor utility bump, deferred because it is not urgent and not a security fix.

## Verification
- Verified current versions from the repository on `main`.
- `bun outdated` on 2026-05-04 no longer lists `react` or `react-dom` after the local two-file update.
- `bun pm hash` succeeds on the locally corrected `bun.lock`.

## Important limitation
- The branch attached to this PR currently contains the `package.json` bump.
- I also prepared the matching `bun.lock` update locally, but could not publish that large generated file through the available GitHub connector flow in this sandbox.
- Do not merge until `bun.lock` is refreshed on this branch with `bun install` and committed alongside the version bump.

## Local prepared fix
- Local branch: `codex/dependency-sweep-react-19-2-5-main-20260504`
- Local commit with both files updated: `6ae9cec`
