### PR TITLE
fix(ui): reserve scrollbar gutter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,9 @@
     --radius: 0.625rem;
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);
+    --scrollbar-track: oklch(0.985 0 0);
+    --scrollbar-thumb: oklch(0.72 0.012 255);
+    --scrollbar-thumb-hover: oklch(0.56 0.018 255);
     --card: oklch(1 0 0);
     --card-foreground: oklch(0.145 0 0);
     --popover: oklch(1 0 0);
@@ -92,6 +95,9 @@
 .dark {
     --background: oklch(0.145 0 0);
     --foreground: oklch(0.985 0 0);
+    --scrollbar-track: oklch(0.19 0.006 255);
+    --scrollbar-thumb: oklch(0.44 0.012 255);
+    --scrollbar-thumb-hover: oklch(0.62 0.015 255);
     --card: oklch(0.205 0 0);
     --card-foreground: oklch(0.985 0 0);
     --popover: oklch(0.205 0 0);
@@ -121,6 +127,37 @@
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
+}
+
+html {
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+}
+
+@supports not (scrollbar-gutter: stable) {
+    html {
+        overflow-y: scroll;
+    }
+}
+
+::-webkit-scrollbar {
+    width: 12px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+    background-clip: content-box;
+    background-color: var(--scrollbar-thumb);
+    border: 3px solid transparent;
+    border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scrollbar-thumb-hover);
 }
 
 /* Animations fluides et optimisées */


### PR DESCRIPTION
## Résumé
- Réserve l’espace de scrollbar au niveau du document avec `scrollbar-gutter: stable`.
- Ajoute un fallback `overflow-y: scroll` pour les navigateurs sans support du gutter.
- Stylise la scrollbar avec des variables light/dark, `scrollbar-color` et les pseudo-éléments WebKit.

## Validation
- `bun --bun next build` : OK.
- Hook de commit Husky (`bun --bun next build`) : OK.
- Browser QA sur `http://localhost:3000` : contenu rendu, pas d’overlay d’erreur Next, scroll fonctionnel, styles calculés avec `scrollbar-gutter: stable` en desktop 1280x720 et mobile 390x844.

## Note
- `bun run lint` échoue sur `spawnSync biome ENOENT` : le script Ultracite attend un binaire `biome` qui n’est pas disponible dans les dépendances du projet actuel.