### PR TITLE
fix(deploy): add wrangler static assets config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 .vercel
+
+# wrangler files
+.wrangler
+.dev.vars*
+!.dev.vars.example
+!.env.example

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "name": "williamdeazevedo2025",
+  "compatibility_date": "2026-06-19",
+  "assets": {
+    "directory": "./dist"
+  },
+  "build": {
+    "command": "bun run build"
+  }
+}


### PR DESCRIPTION
## What changed

Added an assets-only `wrangler.jsonc` so Cloudflare Workers deploys the Astro static `dist` output directly.

Updated `.gitignore` for Wrangler local files.

## Why

Wrangler auto-config was injecting the Astro Cloudflare SSR adapter during deploy, which failed against the currently pinned Astro version with `Missing "./app/fetch/default-handler" specifier in "astro" package`.

This site builds static pages, so the Cloudflare adapter is not needed for deployment.

## Validation

- `bun run build`
- `bunx wrangler deploy --dry-run`