### PR TITLE
Perf: defer carousel and optimize matrices

### DIFF
--- a/src/components/AboutLogoMatrix.astro
+++ b/src/components/AboutLogoMatrix.astro
@@ -50,8 +50,12 @@ const classes = ["about-logo-matrix", className, classAttribute]
                 const source = root.querySelector<SVGSVGElement>("svg");
                 const context = canvas?.getContext("2d");
                 const probe = document.createElement("canvas").getContext("2d");
+                const staticCanvas = document.createElement("canvas");
+                const staticContext = staticCanvas.getContext("2d");
 
-                if (!canvas || !source || !context || !probe) return;
+                if (!canvas || !source || !context || !probe || !staticContext) {
+                    return;
+                }
 
                 root.dataset.aboutLogoMatrixReady = "true";
 
@@ -80,6 +84,9 @@ const classes = ["about-logo-matrix", className, classAttribute]
                 let isActive = false;
                 let lastRender = 0;
                 let color = "255 255 255";
+                let width = 0;
+                let height = 0;
+                let hasPainted = false;
 
                 const stop = () => {
                     isActive = false;
@@ -92,52 +99,65 @@ const classes = ["about-logo-matrix", className, classAttribute]
 
                 const resize = () => {
                     const rect = root.getBoundingClientRect();
-                    const ratio = Math.min(window.devicePixelRatio || 1, 2);
-                    const gap = rect.width > 720 ? 7 : 6;
+                    width = rect.width;
+                    height = rect.height;
+                    const ratio = Math.min(window.devicePixelRatio || 1, 1.5);
+                    const gap = width > 720 ? 9 : 7;
 
-                    if (rect.width === 0 || rect.height === 0) return;
+                    if (width === 0 || height === 0) return;
 
                     color =
                         getComputedStyle(root)
                             .getPropertyValue("--about-logo-matrix-color")
                             .trim() || "255 255 255";
 
-                    canvas.width = Math.max(1, Math.floor(rect.width * ratio));
-                    canvas.height = Math.max(
-                        1,
-                        Math.floor(rect.height * ratio),
-                    );
+                    canvas.width = Math.max(1, Math.floor(width * ratio));
+                    canvas.height = Math.max(1, Math.floor(height * ratio));
+                    staticCanvas.width = canvas.width;
+                    staticCanvas.height = canvas.height;
                     context.setTransform(ratio, 0, 0, ratio, 0, 0);
+                    staticContext.setTransform(ratio, 0, 0, ratio, 0, 0);
+                    staticContext.clearRect(0, 0, width, height);
                     dots = [];
 
-                    for (let y = 1; y < rect.height; y += gap) {
-                        for (let x = 1; x < rect.width; x += gap) {
-                            const sourceX = (x / rect.width) * 53;
-                            const sourceY = (y / rect.height) * 30;
+                    for (let y = 1; y < height; y += gap) {
+                        for (let x = 1; x < width; x += gap) {
+                            const sourceX = (x / width) * 53;
+                            const sourceY = (y / height) * 30;
                             const active = paths.some((path) =>
                                 probe.isPointInPath(path, sourceX, sourceY),
                             );
-
-                            dots.push({
+                            const size = active ? 1.45 : 0.95;
+                            const alpha = active
+                                ? 0.12 + Math.random() * 0.24
+                                : 0.015 + Math.random() * 0.035;
+                            const dot = {
                                 x,
                                 y,
-                                size: active ? 1.45 : 0.95,
-                                alpha: active
-                                    ? 0.12 + Math.random() * 0.24
-                                    : 0.015 + Math.random() * 0.035,
+                                size,
+                                alpha,
                                 phase: Math.random() * Math.PI * 2,
                                 speed: 0.0018 + Math.random() * 0.0032,
                                 interval: 220 + Math.random() * 620,
                                 pop: active ? 0.28 : 0.16,
-                            });
+                            };
+
+                            if (!active) {
+                                staticContext.fillStyle = `rgb(${color} / ${alpha})`;
+                                staticContext.fillRect(x, y, size, size);
+                                continue;
+                            }
+
+                            dots.push(dot);
                         }
                     }
                 };
 
                 const render = (time = 0) => {
-                    const rect = root.getBoundingClientRect();
+                    if (width === 0 || height === 0) return;
 
-                    context.clearRect(0, 0, rect.width, rect.height);
+                    context.clearRect(0, 0, width, height);
+                    context.drawImage(staticCanvas, 0, 0, width, height);
 
                     dots.forEach((dot) => {
                         const wave = prefersReducedMotion
@@ -173,6 +193,14 @@ const classes = ["about-logo-matrix", className, classAttribute]
                     isActive = true;
                     frame = window.requestAnimationFrame(tick);
                 };
+                const paint = () => {
+                    if (hasPainted) return;
+
+                    hasPainted = true;
+                    resizeObserver.observe(root);
+                    resize();
+                    render(performance.now());
+                };
 
                 const resizeObserver = new ResizeObserver(() => {
                     resize();
@@ -181,12 +209,13 @@ const classes = ["about-logo-matrix", className, classAttribute]
                 const visibilityObserver = new IntersectionObserver(
                     ([entry]) => {
                         if (entry?.isIntersecting) {
+                            paint();
                             start();
                         } else {
                             stop();
                         }
                     },
-                    { rootMargin: "160px" },
+                    { rootMargin: "320px" },
                 );
                 const state = {
                     destroy: () => {
@@ -201,11 +230,13 @@ const classes = ["about-logo-matrix", className, classAttribute]
 
                 activeStates.add(state);
                 stateByRoot.set(root, state);
-                resizeObserver.observe(root);
-                resize();
-                render();
 
-                if (!prefersReducedMotion) visibilityObserver.observe(root);
+                if ("IntersectionObserver" in window) {
+                    visibilityObserver.observe(root);
+                } else {
+                    paint();
+                    start();
+                }
             });
     };
     const resetAboutLogoMatrices = () => {

--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -104,344 +104,96 @@ const { autoplay = false, autoplayDelay = 4500 } = Astro.props;
 </div>
 
 <script>
-    import EmblaCarousel from "embla-carousel";
-
-    type CarouselState = {
-        cleanup: Array<() => void>;
-        destroyed: boolean;
-        lazyObserver?: IntersectionObserver;
-        started: boolean;
-        wrapperNode: HTMLElement;
+    type CarouselModule = typeof import("../scripts/carousel");
+    type CarouselLoaderState = {
+        observer?: IntersectionObserver;
+        root: HTMLElement;
     };
 
-    const windowWithCarousel = window as Window & {
-        __wuiCarouselLifecycleReady?: boolean;
-        __wuiCarouselStates?: Set<CarouselState>;
+    const windowWithCarouselLoader = window as Window & {
+        __wuiCarouselLoaderLifecycleReady?: boolean;
+        __wuiCarouselLoaderStates?: Set<CarouselLoaderState>;
+        __wuiCarouselModulePromise?: Promise<CarouselModule>;
     };
-    const activeCarouselStates =
-        windowWithCarousel.__wuiCarouselStates ?? new Set<CarouselState>();
-    windowWithCarousel.__wuiCarouselStates = activeCarouselStates;
-    const carouselStateByRoot = new WeakMap<HTMLElement, CarouselState>();
+    const activeCarouselLoaderStates =
+        windowWithCarouselLoader.__wuiCarouselLoaderStates ??
+        new Set<CarouselLoaderState>();
+    windowWithCarouselLoader.__wuiCarouselLoaderStates =
+        activeCarouselLoaderStates;
 
-    const pauseVideo = (video: HTMLVideoElement) => {
-        video.dataset.carouselActive = "false";
-        video.pause();
-        video.currentTime = 0;
-        video.preload = "none";
-    };
+    const carouselLoaderStateByRoot = new WeakMap<
+        HTMLElement,
+        CarouselLoaderState
+    >();
 
-    function destroyCarousel(state: CarouselState) {
-        if (state.destroyed) return;
-
-        state.destroyed = true;
-        state.lazyObserver?.disconnect();
-        state.cleanup.splice(0).forEach((cleanup) => cleanup());
-        state.wrapperNode
-            .querySelectorAll<HTMLVideoElement>("video")
-            .forEach(pauseVideo);
-        state.wrapperNode
-            .querySelector<HTMLElement>(".embla__viewport")
-            ?.classList.remove("is-ready");
-        delete state.wrapperNode.dataset.initialized;
-        delete state.wrapperNode.dataset.carouselAutoplayVisible;
-        carouselStateByRoot.delete(state.wrapperNode);
-        activeCarouselStates.delete(state);
-    }
-
-    function resetCarousels() {
-        Array.from(activeCarouselStates).forEach(destroyCarousel);
-    }
-
-    function initCarousel(wrapperNode: HTMLElement) {
-        if (carouselStateByRoot.has(wrapperNode)) return;
-        if (wrapperNode.dataset.initialized === "true") return;
-
-        const viewportNode =
-            wrapperNode.querySelector<HTMLElement>(".embla__viewport");
-        const prevButtonNode = wrapperNode.querySelector(".embla__prev");
-        const nextButtonNode = wrapperNode.querySelector(".embla__next");
-        const autoplayButtonNode =
-            wrapperNode.querySelector<HTMLButtonElement>(
-                "[data-carousel-autoplay-toggle]",
-            );
-        const progressNode = wrapperNode.querySelector<HTMLElement>(
-            "[data-carousel-progress]",
+    const loadCarouselModule = () => {
+        windowWithCarouselLoader.__wuiCarouselModulePromise ??= import(
+            "../scripts/carousel"
         );
 
-        if (!viewportNode || !prevButtonNode || !nextButtonNode) return;
+        return windowWithCarouselLoader.__wuiCarouselModulePromise;
+    };
 
-        const slides = wrapperNode.querySelectorAll<HTMLElement>(".embla__slide");
-        const videos = wrapperNode.querySelectorAll<HTMLVideoElement>("video");
+    const loadCarousel = (root: HTMLElement) => {
+        void loadCarouselModule().then(({ initCarousel }) => initCarousel(root));
+    };
 
-        wrapperNode.dataset.initialized = "true";
-        const state: CarouselState = {
-            cleanup: [],
-            destroyed: false,
-            started: false,
-            wrapperNode,
+    const destroyLoader = (state: CarouselLoaderState) => {
+        state.observer?.disconnect();
+        carouselLoaderStateByRoot.delete(state.root);
+        activeCarouselLoaderStates.delete(state);
+        delete state.root.dataset.carouselLoaderReady;
+    };
+
+    const resetCarouselLoaders = () => {
+        Array.from(activeCarouselLoaderStates).forEach(destroyLoader);
+        windowWithCarouselLoader.__wuiCarouselModulePromise?.then(
+            ({ resetCarousels }) => resetCarousels(),
+        );
+    };
+
+    const bindCarouselLoader = (root: HTMLElement) => {
+        if (carouselLoaderStateByRoot.has(root)) return;
+        if (root.dataset.carouselLoaderReady === "true") return;
+
+        const state: CarouselLoaderState = { root };
+        const load = () => {
+            destroyLoader(state);
+            loadCarousel(root);
         };
 
-        carouselStateByRoot.set(wrapperNode, state);
-        activeCarouselStates.add(state);
+        root.dataset.carouselLoaderReady = "true";
+        carouselLoaderStateByRoot.set(root, state);
+        activeCarouselLoaderStates.add(state);
 
-        const startCarousel = () => {
-            if (state.destroyed || state.started) return;
+        if (!("IntersectionObserver" in window)) {
+            load();
+            return;
+        }
 
-            state.started = true;
-            const emblaApi = EmblaCarousel(viewportNode, {
-                loop: true,
-                align: "center",
-            });
-            state.cleanup.push(() => emblaApi.destroy());
-            let lastDispatchedIndex = emblaApi.selectedScrollSnap();
-            let isSettled = true;
-            let canUpdateVideos = true;
-            let scheduleAutoplay = () => {};
-            let cancelAutoplay = () => {};
-
-            const playVideo = (video: HTMLVideoElement) => {
-                video.dataset.carouselActive = "true";
-                video.preload = "auto";
-
-                const play = () => {
-                    if (video.dataset.carouselActive !== "true") return;
-
-                    void video.play().catch(() => {});
-                };
-
-                if (video.readyState < 2 && video.dataset.carouselPlayQueued !== "true") {
-                    video.dataset.carouselPlayQueued = "true";
-                    video.addEventListener(
-                        "loadeddata",
-                        () => {
-                            delete video.dataset.carouselPlayQueued;
-                            play();
-                        },
-                        { once: true },
-                    );
-                    video.load();
-                }
-
-                window.requestAnimationFrame(play);
-            };
-
-            function dispatchSlideChange() {
-                const activeIndex = emblaApi.selectedScrollSnap();
-
-                if (activeIndex !== lastDispatchedIndex) {
-                    const previousIndex = emblaApi.previousScrollSnap();
-                    const snapCount = emblaApi.scrollSnapList().length;
-                    const delta =
-                        (activeIndex - previousIndex + snapCount) % snapCount;
-                    const direction = delta <= snapCount / 2 ? "next" : "prev";
-
-                    lastDispatchedIndex = activeIndex;
-                    wrapperNode.dispatchEvent(
-                        new CustomEvent("carousel:select", {
-                            bubbles: true,
-                            detail: { direction, index: activeIndex },
-                        }),
-                    );
-                }
-            }
-
-            function updateVideos() {
-                const activeSlide = slides[emblaApi.selectedScrollSnap()];
-
-                videos.forEach((video) => {
-                    if (activeSlide?.contains(video)) {
-                        playVideo(video);
-                        return;
-                    }
-
-                    pauseVideo(video);
-                });
-            }
-
-            emblaApi.on("select", () => {
-                isSettled = false;
-                dispatchSlideChange();
-            });
-            emblaApi.on("settle", () => {
-                isSettled = true;
-                if (canUpdateVideos) updateVideos();
-                scheduleAutoplay();
-            });
-
-            emblaApi.on("init", () => viewportNode.classList.add("is-ready"));
-
-            const shouldAutoplay =
-                wrapperNode.dataset.carouselAutoplay === "true" &&
-                !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-            canUpdateVideos = !shouldAutoplay;
-            if (canUpdateVideos) updateVideos();
-
-            const scrollPrev = () => {
-                cancelAutoplay();
-                emblaApi.scrollPrev();
-            };
-            const scrollNext = () => {
-                cancelAutoplay();
-                emblaApi.scrollNext();
-            };
-
-            prevButtonNode.addEventListener("click", scrollPrev);
-            nextButtonNode.addEventListener("click", scrollNext);
-            state.cleanup.push(() => {
-                prevButtonNode.removeEventListener("click", scrollPrev);
-                nextButtonNode.removeEventListener("click", scrollNext);
-            });
-
-            if (shouldAutoplay) {
-                let isInAutoplayZone = false;
-                let isPaused = false;
-                let progressAnimation: Animation | undefined;
-                let progressRun = 0;
-                const delay =
-                    Number(wrapperNode.dataset.carouselAutoplayDelay) || 4500;
-
-                const resetProgress = () => {
-                    progressRun += 1;
-                    progressAnimation?.cancel();
-                    progressAnimation = undefined;
-                    if (progressNode) progressNode.style.transform = "scaleX(0)";
-                };
-
-                const startProgress = () => {
-                    if (!progressNode || !isInAutoplayZone || isPaused) return;
-
-                    resetProgress();
-                    const currentRun = progressRun;
-
-                    progressAnimation = progressNode.animate(
-                        [
-                            { transform: "scaleX(0)", offset: 0 },
-                            { transform: "scaleX(1)", offset: 0.94 },
-                            { transform: "scaleX(1)", offset: 1 },
-                        ],
-                        {
-                            duration: delay,
-                            easing: "linear",
-                            fill: "forwards",
-                        },
-                    );
-
-                    progressAnimation.finished
-                        .then(() => {
-                            if (
-                                state.destroyed ||
-                                currentRun !== progressRun ||
-                                !document.contains(wrapperNode) ||
-                                !isInAutoplayZone ||
-                                isPaused
-                            ) {
-                                return;
-                            }
-
-                            progressNode.style.transform = "scaleX(1)";
-                            emblaApi.scrollNext();
-                        })
-                        .catch(() => {});
-                };
-
-                const syncPausedUi = () => {
-                    autoplayButtonNode?.setAttribute(
-                        "aria-pressed",
-                        String(isPaused),
-                    );
-                    autoplayButtonNode?.setAttribute(
-                        "aria-label",
-                        isPaused
-                            ? "Relancer le carousel"
-                            : "Mettre le carousel en pause",
-                    );
-                };
-
-                const clearAutoplay = () => {
-                    resetProgress();
-                };
-                const toggleUserPaused = () => {
-                    isPaused = !isPaused;
-                    scheduleAutoplay();
-                };
-
-                scheduleAutoplay = () => {
-                    syncPausedUi();
-                    if (state.destroyed || !isInAutoplayZone || isPaused) {
-                        clearAutoplay();
-                        return;
-                    }
-
-                    startProgress();
-                };
-                cancelAutoplay = clearAutoplay;
-
-                const autoplayObserver = new IntersectionObserver(
-                    (entries) => {
-                        const nextIsInAutoplayZone =
-                            entries[0]?.isIntersecting ?? false;
-
-                        if (nextIsInAutoplayZone === isInAutoplayZone) return;
-
-                        isInAutoplayZone = nextIsInAutoplayZone;
-                        canUpdateVideos = isInAutoplayZone;
-                        wrapperNode.dataset.carouselAutoplayVisible =
-                            String(isInAutoplayZone);
-
-                        if (isInAutoplayZone) {
-                            updateVideos();
-                            if (isSettled) scheduleAutoplay();
-                        } else {
-                            clearAutoplay();
-                            videos.forEach(pauseVideo);
-                        }
-                    },
-                    { threshold: 0.2 },
-                );
-
-                autoplayObserver.observe(wrapperNode);
-                syncPausedUi();
-                state.cleanup.push(() => {
-                    autoplayObserver.disconnect();
-                    resetProgress();
-                });
-
-                autoplayButtonNode?.addEventListener("click", toggleUserPaused);
-                state.cleanup.push(() => {
-                    autoplayButtonNode?.removeEventListener(
-                        "click",
-                        toggleUserPaused,
-                    );
-                });
-            }
-        };
-
-        const observer = new IntersectionObserver(
+        state.observer = new IntersectionObserver(
             (entries) => {
                 if (!entries[0]?.isIntersecting) return;
 
-                observer.disconnect();
-                startCarousel();
+                load();
             },
-            { rootMargin: "120px 0px" },
+            { rootMargin: "480px 0px" },
         );
+        state.observer.observe(root);
+    };
 
-        state.lazyObserver = observer;
-        observer.observe(wrapperNode);
-    }
-
-    function init() {
+    const initCarouselLoaders = () => {
         document
             .querySelectorAll<HTMLElement>("[data-carousel]")
-            .forEach(initCarousel);
-    }
+            .forEach(bindCarouselLoader);
+    };
 
-    init();
+    initCarouselLoaders();
 
-    if (windowWithCarousel.__wuiCarouselLifecycleReady !== true) {
-        windowWithCarousel.__wuiCarouselLifecycleReady = true;
-        document.addEventListener("astro:before-swap", resetCarousels);
-        document.addEventListener("astro:page-load", init);
+    if (windowWithCarouselLoader.__wuiCarouselLoaderLifecycleReady !== true) {
+        windowWithCarouselLoader.__wuiCarouselLoaderLifecycleReady = true;
+        document.addEventListener("astro:before-swap", resetCarouselLoaders);
+        document.addEventListener("astro:page-load", initCarouselLoaders);
     }
 </script>
 

--- a/src/components/HeroDotMatrix.astro
+++ b/src/components/HeroDotMatrix.astro
@@ -145,6 +145,8 @@
                 let frame = 0;
                 let isActive = false;
                 let lastRender = 0;
+                let width = 0;
+                let height = 0;
                 const randomUnit = (seed: number) => {
                     const value = Math.sin(seed) * 10000;
                     return value - Math.floor(value);
@@ -160,24 +162,23 @@
 
                 const resize = () => {
                     const rect = root.getBoundingClientRect();
+                    width = rect.width;
+                    height = rect.height;
                     const ratio = Math.min(window.devicePixelRatio || 1, 2);
-                    const gap = rect.width > 720 ? 5 : 4;
+                    const gap = width > 720 ? 5 : 4;
 
-                    if (rect.width === 0 || rect.height === 0) return;
+                    if (width === 0 || height === 0) return;
 
-                    canvas.width = Math.max(1, Math.floor(rect.width * ratio));
-                    canvas.height = Math.max(
-                        1,
-                        Math.floor(rect.height * ratio),
-                    );
+                    canvas.width = Math.max(1, Math.floor(width * ratio));
+                    canvas.height = Math.max(1, Math.floor(height * ratio));
                     context.setTransform(ratio, 0, 0, ratio, 0, 0);
 
                     dots = [];
 
-                    for (let y = 1; y < rect.height; y += gap) {
-                        for (let x = 1; x < rect.width; x += gap) {
-                            const sourceX = (x / rect.width) * 1372;
-                            const sourceY = (y / rect.height) * 59;
+                    for (let y = 1; y < height; y += gap) {
+                        for (let x = 1; x < width; x += gap) {
+                            const sourceX = (x / width) * 1372;
+                            const sourceY = (y / height) * 59;
                             const active =
                                 probe &&
                                 paths.some((path) =>
@@ -201,9 +202,9 @@
                 };
 
                 const render = (time = 0) => {
-                    const rect = root.getBoundingClientRect();
+                    if (width === 0 || height === 0) return;
 
-                    context.clearRect(0, 0, rect.width, rect.height);
+                    context.clearRect(0, 0, width, height);
 
                     dots.forEach((dot) => {
                         const wave = prefersReducedMotion

--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -1,8 +1,15 @@
 ---
-const { title } = Astro.props;
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
 import "../styles/global.css";
+
+interface Props {
+    title?: string;
+}
+
+const siteTitle = "William De Azevedo";
+const { title = siteTitle } = Astro.props;
+const pageTitle = title === siteTitle ? siteTitle : `${title} | ${siteTitle}`;
 ---
 
 <html lang="fr">
@@ -13,7 +20,7 @@ import "../styles/global.css";
         <meta name="viewport" content="width=device-width" />
         <meta name="generator" content={Astro.generator} />
         <link rel="sitemap" href="/sitemap-index.xml" />
-        <title>{title}</title>
+        <title>{pageTitle}</title>
     </head>
     <body class="min-h-screen min-w-0 flex flex-col">
         <Header pathName={Astro.url.pathname} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -299,6 +299,8 @@ const aboutPoints = [
                         ]}
                         data-project-panel
                         data-project-index={index}
+                        aria-hidden={index === 0 ? undefined : "true"}
+                        inert={index === 0 ? undefined : true}
                     >
                         <ProjectIntro
                             href={project.href}
@@ -510,6 +512,7 @@ const aboutPoints = [
 
                         panel.classList.toggle("is-active", isActive);
                         panel.setAttribute("aria-hidden", String(!isActive));
+                        panel.toggleAttribute("inert", !isActive);
                         if (isActive) activePanel = panel;
                     });
 

--- a/src/scripts/carousel.ts
+++ b/src/scripts/carousel.ts
@@ -1,0 +1,301 @@
+import EmblaCarousel from "embla-carousel";
+
+type CarouselState = {
+    cleanup: Array<() => void>;
+    destroyed: boolean;
+    started: boolean;
+    wrapperNode: HTMLElement;
+};
+
+const windowWithCarousel = window as Window & {
+    __wuiCarouselLifecycleReady?: boolean;
+    __wuiCarouselStates?: Set<CarouselState>;
+};
+const activeCarouselStates =
+    windowWithCarousel.__wuiCarouselStates ?? new Set<CarouselState>();
+
+windowWithCarousel.__wuiCarouselStates = activeCarouselStates;
+
+const carouselStateByRoot = new WeakMap<HTMLElement, CarouselState>();
+
+const pauseVideo = (video: HTMLVideoElement) => {
+    video.dataset.carouselActive = "false";
+    video.pause();
+    video.currentTime = 0;
+    video.preload = "none";
+};
+
+export function resetCarousels() {
+    Array.from(activeCarouselStates).forEach(destroyCarousel);
+}
+
+function destroyCarousel(state: CarouselState) {
+    if (state.destroyed) return;
+
+    state.destroyed = true;
+    state.cleanup.splice(0).forEach((cleanup) => cleanup());
+    state.wrapperNode
+        .querySelectorAll<HTMLVideoElement>("video")
+        .forEach(pauseVideo);
+    state.wrapperNode
+        .querySelector<HTMLElement>(".embla__viewport")
+        ?.classList.remove("is-ready");
+    delete state.wrapperNode.dataset.initialized;
+    delete state.wrapperNode.dataset.carouselAutoplayVisible;
+    carouselStateByRoot.delete(state.wrapperNode);
+    activeCarouselStates.delete(state);
+}
+
+export function initCarousel(wrapperNode: HTMLElement) {
+    if (carouselStateByRoot.has(wrapperNode)) return;
+    if (wrapperNode.dataset.initialized === "true") return;
+
+    const viewportNode =
+        wrapperNode.querySelector<HTMLElement>(".embla__viewport");
+    const prevButtonNode = wrapperNode.querySelector(".embla__prev");
+    const nextButtonNode = wrapperNode.querySelector(".embla__next");
+    const autoplayButtonNode = wrapperNode.querySelector<HTMLButtonElement>(
+        "[data-carousel-autoplay-toggle]",
+    );
+    const progressNode = wrapperNode.querySelector<HTMLElement>(
+        "[data-carousel-progress]",
+    );
+
+    if (!viewportNode || !prevButtonNode || !nextButtonNode) return;
+
+    const slides = wrapperNode.querySelectorAll<HTMLElement>(".embla__slide");
+    const videos = wrapperNode.querySelectorAll<HTMLVideoElement>("video");
+
+    wrapperNode.dataset.initialized = "true";
+    const state: CarouselState = {
+        cleanup: [],
+        destroyed: false,
+        started: true,
+        wrapperNode,
+    };
+
+    carouselStateByRoot.set(wrapperNode, state);
+    activeCarouselStates.add(state);
+
+    const emblaApi = EmblaCarousel(viewportNode, {
+        loop: true,
+        align: "center",
+    });
+    state.cleanup.push(() => emblaApi.destroy());
+    let lastDispatchedIndex = emblaApi.selectedScrollSnap();
+    let isSettled = true;
+    let canUpdateVideos = true;
+    let scheduleAutoplay = () => {};
+    let cancelAutoplay = () => {};
+
+    const playVideo = (video: HTMLVideoElement) => {
+        video.dataset.carouselActive = "true";
+        video.preload = "auto";
+
+        const play = () => {
+            if (video.dataset.carouselActive !== "true") return;
+
+            void video.play().catch(() => {});
+        };
+
+        if (video.readyState < 2 && video.dataset.carouselPlayQueued !== "true") {
+            video.dataset.carouselPlayQueued = "true";
+            video.addEventListener(
+                "loadeddata",
+                () => {
+                    delete video.dataset.carouselPlayQueued;
+                    play();
+                },
+                { once: true },
+            );
+            video.load();
+        }
+
+        window.requestAnimationFrame(play);
+    };
+
+    function dispatchSlideChange() {
+        const activeIndex = emblaApi.selectedScrollSnap();
+
+        if (activeIndex !== lastDispatchedIndex) {
+            const previousIndex = emblaApi.previousScrollSnap();
+            const snapCount = emblaApi.scrollSnapList().length;
+            const delta = (activeIndex - previousIndex + snapCount) % snapCount;
+            const direction = delta <= snapCount / 2 ? "next" : "prev";
+
+            lastDispatchedIndex = activeIndex;
+            wrapperNode.dispatchEvent(
+                new CustomEvent("carousel:select", {
+                    bubbles: true,
+                    detail: { direction, index: activeIndex },
+                }),
+            );
+        }
+    }
+
+    function updateVideos() {
+        const activeSlide = slides[emblaApi.selectedScrollSnap()];
+
+        videos.forEach((video) => {
+            if (activeSlide?.contains(video)) {
+                playVideo(video);
+                return;
+            }
+
+            pauseVideo(video);
+        });
+    }
+
+    emblaApi.on("select", () => {
+        isSettled = false;
+        dispatchSlideChange();
+    });
+    emblaApi.on("settle", () => {
+        isSettled = true;
+        if (canUpdateVideos) updateVideos();
+        scheduleAutoplay();
+    });
+
+    emblaApi.on("init", () => viewportNode.classList.add("is-ready"));
+
+    const shouldAutoplay =
+        wrapperNode.dataset.carouselAutoplay === "true" &&
+        !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    canUpdateVideos = !shouldAutoplay;
+    if (canUpdateVideos) updateVideos();
+
+    const scrollPrev = () => {
+        cancelAutoplay();
+        emblaApi.scrollPrev();
+    };
+    const scrollNext = () => {
+        cancelAutoplay();
+        emblaApi.scrollNext();
+    };
+
+    prevButtonNode.addEventListener("click", scrollPrev);
+    nextButtonNode.addEventListener("click", scrollNext);
+    state.cleanup.push(() => {
+        prevButtonNode.removeEventListener("click", scrollPrev);
+        nextButtonNode.removeEventListener("click", scrollNext);
+    });
+
+    if (shouldAutoplay) {
+        let isInAutoplayZone = false;
+        let isPaused = false;
+        let progressAnimation: Animation | undefined;
+        let progressRun = 0;
+        const delay = Number(wrapperNode.dataset.carouselAutoplayDelay) || 4500;
+
+        const resetProgress = () => {
+            progressRun += 1;
+            progressAnimation?.cancel();
+            progressAnimation = undefined;
+            if (progressNode) progressNode.style.transform = "scaleX(0)";
+        };
+
+        const startProgress = () => {
+            if (!progressNode || !isInAutoplayZone || isPaused) return;
+
+            resetProgress();
+            const currentRun = progressRun;
+
+            progressAnimation = progressNode.animate(
+                [
+                    { transform: "scaleX(0)", offset: 0 },
+                    { transform: "scaleX(1)", offset: 0.94 },
+                    { transform: "scaleX(1)", offset: 1 },
+                ],
+                {
+                    duration: delay,
+                    easing: "linear",
+                    fill: "forwards",
+                },
+            );
+
+            progressAnimation.finished
+                .then(() => {
+                    if (
+                        state.destroyed ||
+                        currentRun !== progressRun ||
+                        !document.contains(wrapperNode) ||
+                        !isInAutoplayZone ||
+                        isPaused
+                    ) {
+                        return;
+                    }
+
+                    progressNode.style.transform = "scaleX(1)";
+                    emblaApi.scrollNext();
+                })
+                .catch(() => {});
+        };
+
+        const syncPausedUi = () => {
+            autoplayButtonNode?.setAttribute("aria-pressed", String(isPaused));
+            autoplayButtonNode?.setAttribute(
+                "aria-label",
+                isPaused ? "Relancer le carousel" : "Mettre le carousel en pause",
+            );
+        };
+
+        const clearAutoplay = () => {
+            resetProgress();
+        };
+        const toggleUserPaused = () => {
+            isPaused = !isPaused;
+            scheduleAutoplay();
+        };
+
+        scheduleAutoplay = () => {
+            syncPausedUi();
+            if (state.destroyed || !isInAutoplayZone || isPaused) {
+                clearAutoplay();
+                return;
+            }
+
+            startProgress();
+        };
+        cancelAutoplay = clearAutoplay;
+
+        const autoplayObserver = new IntersectionObserver(
+            (entries) => {
+                const nextIsInAutoplayZone =
+                    entries[0]?.isIntersecting ?? false;
+
+                if (nextIsInAutoplayZone === isInAutoplayZone) return;
+
+                isInAutoplayZone = nextIsInAutoplayZone;
+                canUpdateVideos = isInAutoplayZone;
+                wrapperNode.dataset.carouselAutoplayVisible =
+                    String(isInAutoplayZone);
+
+                if (isInAutoplayZone) {
+                    updateVideos();
+                    if (isSettled) scheduleAutoplay();
+                } else {
+                    clearAutoplay();
+                    videos.forEach(pauseVideo);
+                }
+            },
+            { threshold: 0.2 },
+        );
+
+        autoplayObserver.observe(wrapperNode);
+        syncPausedUi();
+        state.cleanup.push(() => {
+            autoplayObserver.disconnect();
+            resetProgress();
+        });
+
+        autoplayButtonNode?.addEventListener("click", toggleUserPaused);
+        state.cleanup.push(() => {
+            autoplayButtonNode?.removeEventListener("click", toggleUserPaused);
+        });
+    }
+}
+
+if (windowWithCarousel.__wuiCarouselLifecycleReady !== true) {
+    windowWithCarousel.__wuiCarouselLifecycleReady = true;
+    document.addEventListener("astro:before-swap", resetCarousels);
+}


### PR DESCRIPTION
## Summary
- keep the accessibility fixes already on this branch
- lazy-load carousel logic with a tiny viewport loader
- optimize dot matrix canvas rendering and defer the large about matrix

## Checks
- bun run build
- Lighthouse local: performance 0.98, TBT 0 ms, LCP 2.3 s, CLS 0