### PR TITLE
feat(about): update about page design

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,11 +1,262 @@
 ---
 import Layout from "../layout/Layout.astro";
+
+const skillRows = [
+    {
+        label: "Front-end",
+        value: "Astro, React, Next.js, TypeScript, Tailwind CSS",
+    },
+    {
+        label: "Back-end",
+        value: "Node.js, API REST, Drizzle ORM, Prisma, PostgreSQL, Better Auth",
+    },
+    {
+        label: "Produit",
+        value: "Figma, UI design, SEO technique, accessibilité",
+    },
+    {
+        label: "IA",
+        value: "Vercel AI SDK, OpenAI, Claude",
+    },
+    {
+        label: "Outils",
+        value: "Git, GitHub, Vercel, Cloudflare, Docker",
+    },
+];
+
+const certifications = [
+    {
+        image: "/learn-js-jade.png",
+        issuer: "Jade Joubran",
+        name: "Learn JavaScript",
+        url: "https://learnjavascript.online",
+        year: "2024",
+    },
+    {
+        image: "/oc-integ-web-2023.png",
+        issuer: "OpenClassrooms",
+        name: "Développeur intégrateur web",
+        url: "https://openclassrooms.com",
+        year: "2023",
+    },
+    {
+        image: "/oc-dev-jav-react-2025.png",
+        issuer: "OpenClassrooms",
+        name: "Développeur concepteur logiciel",
+        url: "https://openclassrooms.com",
+        year: "2025",
+    },
+];
+
+const pictures = [
+    {
+        alt: "Photo prise au Bourget",
+        className: "rotate-2",
+        src: "/pictures/bourget-opti.jpg",
+    },
+    {
+        alt: "Photo de voyage à Majorque",
+        className: "-rotate-2",
+        src: "/pictures/majorque-opti.jpg",
+    },
+    {
+        alt: "Photo de voyage à Madère",
+        className: "rotate-2",
+        src: "/pictures/madere-opti.jpg",
+    },
+    {
+        alt: "Photo de Goku",
+        className: "-rotate-2 hidden md:block",
+        src: "/pictures/goku-opti.jpg",
+    },
+    {
+        alt: "Photo du setup de travail",
+        className: "rotate-2 hidden md:block",
+        src: "/pictures/desktop-opti.jpg",
+    },
+];
 ---
 
 <Layout
     title="À propos - William De Azevedo"
-    description="En savoir plus sur William De Azevedo, développeur front-end freelance orienté design, performance et produit."
+    description="Développeur front-end avec une approche produit, design et full stack. Découvrez mon parcours, mes projets, mes compétences et mes formations."
 >
-    <h1>About</h1>
-    <p>Hello its me</p>
+    <div class="mx-auto flex w-full max-w-2xl flex-col gap-16 px-4 pb-20">
+        <section class="flex flex-col gap-4">
+            <h1 class="text-4xl font-medium leading-[0.96] text-gray-900 md:text-[56px]">
+                Du graphisme au code, je donne forme à des sites web utiles et
+                soignés.
+            </h1>
+            <p class="max-w-xl text-sm font-light leading-6 text-gray-600">
+                J'aime partir d'une idée, clarifier l'expérience, puis la
+                transformer en interface rapide, accessible et simple à
+                maintenir.
+            </p>
+        </section>
+
+        <section class="flex flex-col gap-4">
+            <h2 class="text-sm font-light text-gray-400">Parcours</h2>
+            <div class="flex flex-col gap-4 text-sm font-light leading-6 text-gray-600">
+                <p>
+                    Mon parcours dans l'infographie, la 3D et le motion design
+                    m'a donné un <span class="font-normal text-gray-900"
+                        >œil aiguisé pour le design</span
+                    > et une sensibilité forte pour les interfaces qui se comprennent
+                    vite.
+                </p>
+                <p>
+                    En 2022, j'ai fait le choix de me reconvertir dans le
+                    développement web pour <span class="font-normal text-gray-900"
+                        >donner vie à mes propres projets</span
+                    >. Depuis, je construis des expériences web avec une approche
+                    front-end, produit et full stack.
+                </p>
+                <p>
+                    Aujourd'hui, je travaille sur des sites vitrines, des
+                    interfaces produit et des applications complètes, avec le
+                    même objectif : livrer quelque chose de clair, rapide et
+                    réellement utile.
+                </p>
+            </div>
+        </section>
+
+        <section class="flex flex-col gap-4">
+            <h2 class="text-sm font-light text-gray-400">Compétences</h2>
+            <div class="flex flex-col gap-2 text-sm font-light">
+                {
+                    skillRows.map((row) => (
+                        <div class="flex items-baseline gap-1">
+                            <span class="shrink-0 text-gray-900">
+                                {row.label}
+                            </span>
+                            <span class="dot-leaders min-w-4 flex-1" />
+                            <span class="min-w-0 text-right text-gray-600">
+                                {row.value}
+                            </span>
+                        </div>
+                    ))
+                }
+            </div>
+        </section>
+
+        <section class="flex flex-col gap-4">
+            <h2 class="text-sm font-light text-gray-400">Formations</h2>
+            <div class="flex flex-col gap-2 text-sm font-light">
+                {
+                    certifications.map((certification) => (
+                        <a
+                            class="certification-row group relative flex items-baseline gap-1 text-gray-900 transition-colors hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                            href={certification.url}
+                            rel="noreferrer"
+                            target="_blank"
+                        >
+                            <span class="min-w-0">{certification.name}</span>
+                            <span class="dot-leaders min-w-4 flex-1" />
+                            <span class="text-right text-gray-600">
+                                {certification.year}
+                            </span>
+                            <span class="certification-preview" aria-hidden="true">
+                                <img
+                                    alt=""
+                                    class="h-full w-full object-contain"
+                                    decoding="async"
+                                    loading="lazy"
+                                    src={certification.image}
+                                />
+                                <span>{certification.issuer}</span>
+                            </span>
+                        </a>
+                    ))
+                }
+            </div>
+        </section>
+
+        <section class="relative left-1/2 w-screen -translate-x-1/2">
+            <div class="photo-strip flex items-center justify-start gap-3 overflow-x-auto px-4 md:justify-center md:gap-5 md:overflow-visible md:px-0">
+                {
+                    pictures.map((picture, index) => (
+                        <div
+                            class:list={[
+                                "aspect-[9/10] w-36 shrink-0 overflow-hidden rounded-lg bg-gray-100 transition-transform duration-300 hover:scale-[1.02] sm:w-40 md:w-44",
+                                picture.className,
+                            ]}
+                        >
+                            <img
+                                alt={picture.alt}
+                                class="h-full w-full object-cover"
+                                decoding="async"
+                                height="196"
+                                loading={index < 3 ? "eager" : "lazy"}
+                                src={picture.src}
+                                width="176"
+                            />
+                        </div>
+                    ))
+                }
+            </div>
+        </section>
+    </div>
 </Layout>
+
+<style>
+    .dot-leaders {
+        overflow: hidden;
+        text-overflow: clip;
+        white-space: nowrap;
+    }
+
+    .dot-leaders::before {
+        color: var(--color-gray-200);
+        content: " · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ";
+        letter-spacing: 4px;
+    }
+
+    .photo-strip {
+        scrollbar-width: none;
+    }
+
+    .photo-strip::-webkit-scrollbar {
+        display: none;
+    }
+
+    .certification-preview {
+        background: var(--color-snow-50);
+        border: 1px solid var(--color-gray-100);
+        border-radius: 0.5rem;
+        bottom: calc(100% + 0.75rem);
+        box-shadow: 0 18px 44px -24px rgb(17 24 39 / 0.35);
+        display: none;
+        height: 13.5rem;
+        left: 50%;
+        overflow: hidden;
+        position: absolute;
+        transform: translateX(-50%) translateY(0.5rem);
+        width: 18rem;
+        z-index: 20;
+    }
+
+    .certification-preview span {
+        background: var(--color-gray-50);
+        border-top: 1px solid var(--color-gray-100);
+        bottom: 0;
+        color: var(--color-gray-500);
+        font-size: 0.75rem;
+        left: 0;
+        padding: 0.5rem 0.75rem;
+        position: absolute;
+        width: 100%;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        .certification-row:hover .certification-preview,
+        .certification-row:focus-visible .certification-preview {
+            display: block;
+        }
+    }
+
+    @media (max-width: 640px) {
+        .dot-leaders::before {
+            letter-spacing: 2px;
+        }
+    }
+</style>


### PR DESCRIPTION
## Summary

- Rebuild the Astro about page from the placeholder into a complete profile page.
- Add parcours, competences, formations with certificate previews, and the photo strip from the previous design direction.
- Adjust the hero copy after browser review comments and remove the projects block from this page.

## Validation

- `bun run build`