### PR TITLE
fix(article): align motivia comparison images

### DIFF
--- a/src/components/articles/MotiviaOldUI.astro
+++ b/src/components/articles/MotiviaOldUI.astro
@@ -110,8 +110,12 @@ const oldSrc =
     }
 
     .ui-compare__img {
+        border-radius: 0;
+        display: block;
         height: 100%;
         inset: 0;
+        margin: 0;
+        max-width: none;
         object-fit: cover;
         object-position: top;
         position: absolute;


### PR DESCRIPTION
## Summary

- Neutralizes global article image styles inside the Motivai before/after comparison slider.
- Keeps the screenshots flush with the comparison frame so the border no longer looks offset.

## Validation

- `bun run build`
- `bun run lint`
- `git diff --cached --check`

Note: global `bun run format:check` still reports an unrelated existing formatting issue in `src/lib/articles.ts`.