### PR TITLE
feat(seo): métadonnées articles, breadcrumbs, prefetch & accessibilité

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,14 @@ export default defineConfig({
   site: "https://williamdeazevedo.fr/",
   integrations: [mdx(), sitemap()],
 
+  // Prefetch internal links on hover/focus so navigation feels instant
+  // (improves perceived performance & Core Web Vitals). Astro skips this
+  // automatically when the user has Save-Data enabled.
+  prefetch: {
+    prefetchAll: true,
+    defaultStrategy: "hover",
+  },
+
   markdown: {
     shikiConfig: {
       theme: "github-dark-dimmed",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,7 +21,7 @@ const items = navItems.map((item) => ({
 ---
 
 <header class="w-full p-2 mb-12 sm:p-4">
-    <nav class="max-w-5xl mx-auto sm:p-4">
+    <nav aria-label="Navigation principale" class="max-w-5xl mx-auto sm:p-4">
         <ul
             class="relative flex flex-wrap gap-1 justify-center items-center text-sm font-light sm:gap-4 sm:text-base"
         >

--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -7,12 +7,23 @@ interface Props {
     title?: string;
     description?: string;
     image?: string;
+    imageAlt?: string;
+    ogType?: "website" | "article" | "profile";
+    article?: {
+        publishedTime?: string;
+        modifiedTime?: string;
+        author?: string;
+        tags?: string[];
+    };
 }
 
 const {
     title = "William De Azevedo - Développeur front-end freelance",
     description = "Développeur front-end freelance orienté design et produit, je crée des sites rapides, accessibles et pensés pour convertir.",
     image = "/pictures/william-low.png",
+    imageAlt = "William De Azevedo, développeur front-end freelance",
+    ogType = "website",
+    article,
 } = Astro.props;
 
 const siteName = "William De Azevedo";
@@ -81,15 +92,44 @@ const personJsonLd = {
         <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
         <meta property="og:locale" content="fr_FR" />
         <meta property="og:site_name" content={siteName} />
-        <meta property="og:type" content="website" />
+        <meta property="og:type" content={ogType} />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:url" content={canonicalUrl.href} />
         <meta property="og:image" content={imageUrl.href} />
-        <meta name="twitter:card" content="summary_large_image" />
+        <meta property="og:image:alt" content={imageAlt} />
+        {
+            article && (
+                <>
+                    {article.publishedTime && (
+                        <meta
+                            property="article:published_time"
+                            content={article.publishedTime}
+                        />
+                    )}
+                    {article.modifiedTime && (
+                        <meta
+                            property="article:modified_time"
+                            content={article.modifiedTime}
+                        />
+                    )}
+                    {article.author && (
+                        <meta
+                            property="article:author"
+                            content={article.author}
+                        />
+                    )}
+                    {article.tags?.map((tag) => (
+                        <meta property="article:tag" content={tag} />
+                    ))}
+                </>
+            )
+        }
+        <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />
         <meta name="twitter:image" content={imageUrl.href} />
+        <meta name="twitter:image:alt" content={imageAlt} />
         <script
             type="application/ld+json"
             is:inline
@@ -98,10 +138,48 @@ const personJsonLd = {
         <title>{title}</title>
     </head>
     <body class="min-h-screen min-w-0 flex flex-col">
+        <a class="skip-link" href="#main-content">
+            Aller au contenu principal
+        </a>
         <Header pathName={Astro.url.pathname} />
-        <main class="flex-1 flex flex-col gap-8">
+        <main id="main-content" tabindex="-1" class="flex-1 flex flex-col gap-8">
             <slot />
         </main>
         <Footer />
     </body>
 </html>
+
+<style>
+    /* Keyboard "skip to content" shortcut: hidden until focused. */
+    .skip-link {
+        position: fixed;
+        top: 0.75rem;
+        left: 0.75rem;
+        z-index: 100;
+        padding: 0.6rem 1rem;
+        border-radius: 0.7rem;
+        background: var(--color-coffee-300);
+        color: var(--color-snow-50);
+        font-size: 0.875rem;
+        text-decoration: none;
+        transform: translateY(-160%);
+        transition: transform 220ms cubic-bezier(0.2, 0, 0, 1);
+    }
+
+    .skip-link:focus-visible {
+        transform: translateY(0);
+        outline: 2px solid var(--color-blue-500);
+        outline-offset: 3px;
+    }
+
+    /* Don't paint a focus ring around <main> when focus is moved to it. */
+    main:focus {
+        outline: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .skip-link {
+            transition: none;
+        }
+    }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -104,7 +104,7 @@ const pictures = [
         </section>
 
         <section class="flex flex-col gap-4">
-            <h2 class="text-sm font-light text-gray-400">Parcours</h2>
+            <h2 class="text-sm font-light text-gray-500">Parcours</h2>
             <div class="flex flex-col gap-4 text-sm font-light leading-6 text-gray-600">
                 <p>
                     Mon parcours dans l'infographie, la 3D et le motion design
@@ -130,7 +130,7 @@ const pictures = [
         </section>
 
         <section class="flex flex-col gap-4">
-            <h2 class="text-sm font-light text-gray-400">Compétences</h2>
+            <h2 class="text-sm font-light text-gray-500">Compétences</h2>
             <div class="flex flex-col gap-2 text-sm font-light">
                 {
                     skillRows.map((row) => (
@@ -149,7 +149,7 @@ const pictures = [
         </section>
 
         <section class="flex flex-col gap-4">
-            <h2 class="text-sm font-light text-gray-400">Formations</h2>
+            <h2 class="text-sm font-light text-gray-500">Formations</h2>
             <div class="flex flex-col gap-2 text-sm font-light">
                 {
                     certifications.map((certification) => (

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -31,24 +31,71 @@ const jsonLd = {
     "@type": "BlogPosting",
     headline: title,
     description,
+    inLanguage: "fr-FR",
     datePublished: pubDate.toISOString(),
     dateModified: (updatedDate ?? pubDate).toISOString(),
     image: ogImage.href,
     url: canonicalUrl.href,
     mainEntityOfPage: canonicalUrl.href,
+    keywords: article.data.tags,
     author: {
         "@type": "Person",
         name: author,
         url: siteUrl.href,
     },
+    publisher: {
+        "@type": "Person",
+        name: author,
+        url: siteUrl.href,
+    },
+};
+
+const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+        {
+            "@type": "ListItem",
+            position: 1,
+            name: "Accueil",
+            item: siteUrl.href,
+        },
+        {
+            "@type": "ListItem",
+            position: 2,
+            name: "Articles",
+            item: new URL("/articles", siteUrl).href,
+        },
+        {
+            "@type": "ListItem",
+            position: 3,
+            name: title,
+            item: canonicalUrl.href,
+        },
+    ],
 };
 ---
 
-<Layout title={`${title} - William De Azevedo`} description={description}>
+<Layout
+    title={`${title} - William De Azevedo`}
+    description={description}
+    ogType="article"
+    article={{
+        publishedTime: pubDate.toISOString(),
+        modifiedTime: (updatedDate ?? pubDate).toISOString(),
+        author,
+        tags: article.data.tags,
+    }}
+>
     <script
         type="application/ld+json"
         is:inline
         set:html={JSON.stringify(jsonLd)}
+    />
+    <script
+        type="application/ld+json"
+        is:inline
+        set:html={JSON.stringify(breadcrumbJsonLd)}
     />
 
     <article class="mx-auto w-full max-w-2xl px-2 pb-20 sm:px-4">
@@ -89,7 +136,7 @@ const jsonLd = {
                     <div class="text-sm">
                         <p class="font-medium text-gray-900">{author}</p>
                         <time
-                            class="font-light text-gray-400"
+                            class="font-light text-gray-500"
                             datetime={pubDate.toISOString()}
                         >
                             {formatArticleDate(pubDate)}

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -32,7 +32,7 @@ const articles = await getVisibleArticles();
             ) : (
                 <>
                     <FadeReveal delay={0.3}>
-                        <h2 class="mb-10 text-sm font-light text-gray-400">
+                        <h2 class="mb-10 text-sm font-light text-gray-500">
                             Articles
                         </h2>
                     </FadeReveal>
@@ -47,7 +47,7 @@ const articles = await getVisibleArticles();
                                             </h3>
                                             <span class="dot-leaders min-w-8 flex-1" />
                                             <time
-                                                class="whitespace-nowrap text-sm tabular-nums text-gray-400"
+                                                class="whitespace-nowrap text-sm tabular-nums text-gray-500"
                                                 datetime={article.data.pubDate.toISOString()}
                                             >
                                                 {formatArticleDate(article.data.pubDate)}
@@ -59,7 +59,7 @@ const articles = await getVisibleArticles();
                                         {article.data.tags.length > 0 && (
                                             <div class="flex flex-wrap gap-2">
                                                 {article.data.tags.map((tag) => (
-                                                    <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-400">
+                                                    <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
                                                         {tag}
                                                     </span>
                                                 ))}


### PR DESCRIPTION
Améliorations SEO & accessibilité, **sans toucher aux animations** (`prefers-reduced-motion` déjà bien géré, laissé intact). Recherche appuyée sur la doc Astro 6 (context7) et les standards WCAG 2.2 AA / Core Web Vitals 2026 (exa).

## SEO
- **`og:type="article"`** sur les articles (le site était `website` partout) + `article:published_time` / `modified_time` / `author` / `tag`.
- **JSON-LD enrichi** : `BreadcrumbList` (fil d'Ariane → rich results) + `BlogPosting` complété (`publisher`, `inLanguage`, `keywords`).
- **`twitter:card` → `summary`** : l'image OG est carrée (284×284) ; `summary_large_image` exige ≥300px de large et cassait l'aperçu.
- **`og:image:alt` / `twitter:image:alt`** ajoutés.
- **Prefetch des liens internes** (`prefetch: { prefetchAll: true, defaultStrategy: "hover" }`) → navigation quasi-instantanée, bénéfique pour les Core Web Vitals.

## Accessibilité
- **Lien « Aller au contenu principal »** (skip link, WCAG 2.4.1), invisible jusqu'au focus clavier, transition coupée en reduced-motion. Cible `<main id="main-content" tabindex="-1">`.
- **`aria-label="Navigation principale"`** sur la nav du header (les deux landmarks `<nav>` sont maintenant distincts).
- **Contraste** : textes `text-gray-400` (≈ 3.0:1, échec AA) passés en `text-gray-500` (≈ 4.3:1) ; tags sur fond teinté en `text-gray-600`. La hiérarchie « muted » du design est préservée.

## Vérifications
- `bun run build` ✅ · `bun run lint` ✅ · formatage OK sur les fichiers modifiés.
- Markup généré vérifié (skip link, `og:type`, `article:*`, `BreadcrumbList`, prefetch runtime bundlé).

## À suivre (hors PR, nécessite un asset)
- L'image de partage fait **284×284** ; une image **1200×630** dédiée améliorerait les aperçus sociaux et l'éligibilité aux rich results.
- `src/sections/Differenciates.astro` ne contient qu'un frontmatter (aucun template) → `<Differenciates />` ne rend rien ; non modifié ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)