### PR TITLE
fix(view-transitions): clean SPA view transitions + remove hover prefetch

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,12 +16,15 @@ export default defineConfig({
   site: "https://williamdeazevedo.fr/",
   integrations: [mdx(), sitemap()],
 
-  // Prefetch internal links on hover/focus so navigation feels instant
-  // (improves perceived performance & Core Web Vitals). Astro skips this
-  // automatically when the user has Save-Data enabled.
+  // Prefetch internal links on intent (pointer-down / touch-start) rather than
+  // on hover. Hover prefetch fires a full-page fetch every time the cursor
+  // crosses a link, which competes with the homepage hover micro-interactions
+  // on the main thread and makes them feel laggy. "tap" keeps navigation
+  // near-instant (the request starts a few ms before the click) without the
+  // hover jank. Astro still skips prefetch when Save-Data is enabled.
   prefetch: {
     prefetchAll: true,
-    defaultStrategy: "hover",
+    defaultStrategy: "tap",
   },
 
   markdown: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "node scripts/check-client-router.mjs && astro build",
+    "check:router": "node scripts/check-client-router.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "lint": "oxlint",

--- a/scripts/check-client-router.mjs
+++ b/scripts/check-client-router.mjs
@@ -1,0 +1,69 @@
+// Build guard-rail: the interactive components rely on the view-transition
+// lifecycle events (astro:page-load, astro:before-swap, …) to (re)initialise
+// and clean up after every client-side navigation. Those events ONLY fire when
+// <ClientRouter /> is mounted. If someone removes the router but leaves the
+// listeners behind, they silently stop firing and components quietly break
+// (no error) — exactly the regression this project already hit once.
+//
+// This script fails the build when lifecycle events are used in src/ without a
+// <ClientRouter /> anywhere in the project. If the router is present, it passes.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const SRC_DIR = new URL("../src", import.meta.url).pathname;
+const SCANNED_EXTENSIONS = [".astro", ".ts", ".tsx", ".js", ".mjs"];
+const LIFECYCLE_EVENTS = [
+  "astro:page-load",
+  "astro:after-swap",
+  "astro:before-swap",
+  "astro:before-preparation",
+  "astro:after-preparation",
+];
+
+function walk(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = path.join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      files.push(...walk(fullPath));
+    } else if (SCANNED_EXTENSIONS.some((ext) => fullPath.endsWith(ext))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const files = walk(SRC_DIR);
+const usesClientRouter = files.some((file) => {
+  const content = readFileSync(file, "utf-8");
+  return content.includes("ClientRouter");
+});
+
+const offenders = [];
+for (const file of files) {
+  const content = readFileSync(file, "utf-8");
+  const found = LIFECYCLE_EVENTS.filter((event) => content.includes(event));
+  if (found.length > 0) offenders.push({ file, events: found });
+}
+
+if (offenders.length > 0 && !usesClientRouter) {
+  console.error(
+    "\n✗ View-transition lifecycle events are used without <ClientRouter />.\n" +
+      "  These events only fire when the client router is mounted, so the\n" +
+      "  listeners below would silently never run and their components would\n" +
+      "  break after navigation.\n\n" +
+      "  Either re-add <ClientRouter /> (src/layout/Layout.astro) or migrate\n" +
+      "  these scripts to direct initialisation / native page events.\n",
+  );
+  for (const { file, events } of offenders) {
+    console.error(`  - ${file.replace(SRC_DIR, "src")}: ${events.join(", ")}`);
+  }
+  console.error("");
+  process.exit(1);
+}
+
+console.log(
+  usesClientRouter
+    ? "✓ ClientRouter present — view-transition lifecycle events are safe."
+    : "✓ No view-transition lifecycle events in use.",
+);

--- a/src/components/CalDrawer.astro
+++ b/src/components/CalDrawer.astro
@@ -11,6 +11,7 @@ const calLink = String(
     aria-label="Planifier un créneau"
     class="cal-drawer"
     data-cal-drawer
+    transition:persist
 >
     <div class="cal-drawer__header">
         <button

--- a/src/components/animations/FadeRevealOnScroll.astro
+++ b/src/components/animations/FadeRevealOnScroll.astro
@@ -88,5 +88,19 @@ const {
 <script>
     import { initFadeInAnimations } from "../../scripts/animations/fadeIn";
 
+    // Bundled module scripts run only once, so this direct call covers the
+    // first page load. Under <ClientRouter /> the DOM is swapped in place and
+    // this module is not re-executed, so we also (re)observe the freshly
+    // rendered reveal targets on every navigation via astro:page-load.
     initFadeInAnimations(document);
+
+    const windowWithRevealFlag = window as unknown as {
+        __revealOnScrollBound?: boolean;
+    };
+    if (!windowWithRevealFlag.__revealOnScrollBound) {
+        windowWithRevealFlag.__revealOnScrollBound = true;
+        document.addEventListener("astro:page-load", () =>
+            initFadeInAnimations(document),
+        );
+    }
 </script>

--- a/src/components/animations/FadeRevealOnScroll.astro
+++ b/src/components/animations/FadeRevealOnScroll.astro
@@ -86,12 +86,16 @@ const {
 </style>
 
 <script>
-    import { initFadeInAnimations } from "../../scripts/animations/fadeIn";
+    import {
+        initFadeInAnimations,
+        resetFadeInAnimations,
+    } from "../../scripts/animations/fadeIn";
 
     // Bundled module scripts run only once, so this direct call covers the
     // first page load. Under <ClientRouter /> the DOM is swapped in place and
     // this module is not re-executed, so we also (re)observe the freshly
-    // rendered reveal targets on every navigation via astro:page-load.
+    // rendered reveal targets on every navigation via astro:page-load, and
+    // drop the previous page's observer on astro:before-swap.
     initFadeInAnimations(document);
 
     const windowWithRevealFlag = window as unknown as {
@@ -101,6 +105,9 @@ const {
         windowWithRevealFlag.__revealOnScrollBound = true;
         document.addEventListener("astro:page-load", () =>
             initFadeInAnimations(document),
+        );
+        document.addEventListener("astro:before-swap", () =>
+            resetFadeInAnimations(document),
         );
     }
 </script>

--- a/src/components/ui/WaveIcon.astro
+++ b/src/components/ui/WaveIcon.astro
@@ -129,6 +129,18 @@ const offsets = {
     height: 100%;
     justify-content: center;
     width: 100%;
+  }
+
+  /* Promote to a compositor layer only during the interaction (see WaveText)
+     rather than keeping a permanent GPU layer alive for every icon. */
+  .wui-wave-icon:hover .wui-wave-icon__layer,
+  .wui-wave-icon:focus-visible .wui-wave-icon__layer,
+  :global(:where(a, button, [data-wui-wave-parent]):hover)
+    .wui-wave-icon[data-wui-wave-icon-trigger="parent"]
+    .wui-wave-icon__layer,
+  :global(:where(a, button, [data-wui-wave-parent]):focus-visible)
+    .wui-wave-icon[data-wui-wave-icon-trigger="parent"]
+    .wui-wave-icon__layer {
     will-change: transform;
   }
 

--- a/src/components/ui/WaveText.astro
+++ b/src/components/ui/WaveText.astro
@@ -112,7 +112,6 @@ const splitWords = text.trim()
 
     [data-wui-wave-char] {
         display: inline-block;
-        will-change: transform;
     }
 
     [data-wui-wave-row="first"] [data-wui-wave-char] {
@@ -126,6 +125,21 @@ const splitWords = text.trim()
     [data-wui-wave-char] {
         transition: transform 520ms cubic-bezier(0.34, 1.56, 0.64, 1);
         transition-delay: var(--wui-wave-delay, 0ms);
+    }
+
+    /* Only hint the compositor while the interaction is actually happening.
+       A permanent will-change on every character keeps a GPU layer alive for
+       each one (there are dozens on the homepage), which adds memory pressure
+       and makes the hover micro-interactions stutter. */
+    .wui-wave-text:hover [data-wui-wave-char],
+    .wui-wave-text:focus-visible [data-wui-wave-char],
+    :global(:where(a, button, [data-wui-wave-parent]):hover)
+        .wui-wave-text[data-wui-wave-trigger="parent"]
+        [data-wui-wave-char],
+    :global(:where(a, button, [data-wui-wave-parent]):focus-visible)
+        .wui-wave-text[data-wui-wave-trigger="parent"]
+        [data-wui-wave-char] {
+        will-change: transform;
     }
 
     .wui-wave-text:hover

--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from "astro:transitions";
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
 import CalDrawer from "../components/CalDrawer.astro";
@@ -88,6 +89,11 @@ const personJsonLd = {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#ffffff" />
         <meta name="generator" content={Astro.generator} />
+        {/* Client-side routing + view transitions. Swaps the DOM in place so
+            navigation no longer triggers a full reload (the white flash) and
+            fires the astro:page-load / astro:before-swap lifecycle the
+            interactive components rely on to (re)initialise. */}
+        <ClientRouter />
         <script
             is:inline
             async
@@ -99,8 +105,22 @@ const personJsonLd = {
                 dataLayer.push(arguments);
             }
             gtag("js", new Date());
-
-            gtag("config", "G-9G8R67JBFF");
+            // Client-side routing swaps the DOM without a reload, so GA's
+            // automatic page_view (which only fires on a real document load)
+            // would miss every in-app navigation. Disable it here and send one
+            // page_view per page from astro:page-load instead (fires on the
+            // first load *and* after every view transition).
+            gtag("config", "G-9G8R67JBFF", { send_page_view: false });
+            if (!window.__gaPageviewBound) {
+                window.__gaPageviewBound = true;
+                document.addEventListener("astro:page-load", function () {
+                    gtag("event", "page_view", {
+                        page_path: location.pathname + location.search,
+                        page_location: location.href,
+                        page_title: document.title,
+                    });
+                });
+            }
         </script>
         <meta name="description" content={description} />
         <link rel="canonical" href={canonicalUrl.href} />

--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -113,7 +113,7 @@ const personJsonLd = {
             gtag("config", "G-9G8R67JBFF", { send_page_view: false });
             if (!window.__gaPageviewBound) {
                 window.__gaPageviewBound = true;
-                document.addEventListener("astro:page-load", function () {
+                document.addEventListener("astro:page-load", () => {
                     gtag("event", "page_view", {
                         page_path: location.pathname + location.search,
                         page_location: location.href,

--- a/src/scripts/animations/fadeIn.ts
+++ b/src/scripts/animations/fadeIn.ts
@@ -31,3 +31,16 @@ export function initFadeInAnimations(root: Document) {
     .querySelectorAll<HTMLElement>("[data-reveal-on-scroll]:not(.is-visible)")
     .forEach((element) => observer.observe(element));
 }
+
+// An IntersectionObserver holds strong references to every element it observes.
+// Below-the-fold reveals that never intersected are still observed when the page
+// is swapped out, so without this the observer would retain detached nodes from
+// every visited page. Disconnect on astro:before-swap; initFadeInAnimations
+// recreates a fresh observer on the next astro:page-load.
+export function resetFadeInAnimations(root: Document) {
+  const observer = observerByDocument.get(root);
+  if (!observer) return;
+
+  observer.disconnect();
+  observerByDocument.delete(root);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,10 +2,17 @@
 @import "tw-animate-css";
 @import "@fontsource-variable/geist";
 
-@view-transition {
-  navigation: auto;
-}
+/* View transitions are driven by Astro's <ClientRouter /> (client-side, no
+   full reload). The cross-document `@view-transition { navigation: auto }`
+   trigger is intentionally NOT used: it forced a real navigation (the white
+   flash) and ran the page's entrance animations underneath the transition
+   snapshot, so they had already finished by the time the new page appeared.
+   The pseudo-element rules below still style ClientRouter's transition. */
 
+/* Swap the page contents instantly (no root cross-fade) so only the shared
+   nav indicator/labels morph. With a synchronous in-place swap the fresh page
+   is snapshotted in its pre-animation state, so entrance reveals play cleanly
+   on the live DOM afterwards instead of appearing already-completed. */
 ::view-transition-old(root) {
   animation: none;
   opacity: 0;
@@ -28,6 +35,14 @@
   animation-duration: 320ms;
   animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
   z-index: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
 }
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## Contexte

En production, deux problèmes de perception étaient signalés :

1. **Changement de page** → écran blanc, puis le contenu apparaît avec les animations d'entrée **déjà jouées** (on ne les voit pas).
2. **Animations au survol laggées** sur la page d'accueil.

## Diagnostic (recherche Context7 + Exa)

La cause racine : tout le code du site était **déjà écrit pour `<ClientRouter />`** (écouteurs `astro:page-load` / `astro:before-swap` dans `Marquee`, `HeroDotMatrix`, `Carousel`, `AboutLogoMatrix`, la home, etc.), mais le routeur **n'était pas installé**. À la place, des view transitions **cross-document natives** (`@view-transition { navigation: auto }`) avaient été ajoutées en CSS.

Or ces événements de cycle de vie ne se déclenchent **que** avec `<ClientRouter />`. Sans lui, chaque navigation = **rechargement complet de la page** :
- l'**écran blanc** = le reload ;
- les **animations « déjà jouées »** = les reveals tournent sous le snapshot de la transition et sont terminés quand la nouvelle page s'affiche (mécanique confirmée par la doc Astro + l'article tseku.dev sur le flicker du ClientRouter).

Le **lag au survol** venait de `prefetch: { prefetchAll: true, defaultStrategy: "hover" }` : chaque passage de souris sur un lien déclenchait un fetch de page entière, en concurrence avec les micro-interactions sur le thread principal (aggravé par un `will-change` permanent sur chaque caractère des composants Wave).

## Changements

| Commit | Effet |
|---|---|
| `fix(view-transitions): adopt ClientRouter…` | Installe `<ClientRouter />`, retire le `@view-transition` natif → navigation **en place, sans reload ni écran blanc**. Le snapshot capture l'état **avant** animation, donc les reveals se jouent proprement. + garde `prefers-reduced-motion`, `transition:persist` sur le drawer Cal, re-init des reveals au `astro:page-load`, et `page_view` GA à chaque navigation. |
| `perf(prefetch): switch from hover to tap…` | Plus de fetch au survol → fin du lag hover, navigation toujours quasi instantanée (prefetch au pointer-down). |
| `perf(wave): promote characters to the GPU only while interacting` | `will-change` limité au hover/focus → moins de couches GPU permanentes. |

## Pourquoi `transition:persist` sur le drawer Cal

Son script met en cache la référence du `<dialog>` **une seule fois** au chargement. Sans persistance, le `<dialog>` est remplacé à chaque navigation client et le CTA « Parlons de votre projet » casserait après la 1ʳᵉ navigation.

## Vérification (build + navigateur réel)

- `bun run build` ✅ (6 pages générées, aucune erreur)
- Navigation `/` → `/about` → `/articles` pilotée au navigateur :
  - **navigation 100 % client-side** confirmée (un flag `window` posé avant la navigation **survit** → aucun reload → **plus d'écran blanc**) ✅
  - **aucune erreur JS** en console pendant les navigations ✅
  - `page_view` GA envoyé à chaque navigation (dataLayer grandit) ✅
  - hero/contenu visibles (`opacity: 1`, pas de FOUC) ✅
  - **drawer Cal s'ouvre toujours** après navigation (`transition:persist`) ✅
  - état du lien actif + `view-transition-name` corrects ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)