### PR TITLE
perf: fix Lighthouse score (defer Cal embed, cache media, a11y)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,22 @@
+# Cloudflare honours this file for static assets (copied to dist/_headers).
+# Fixes Lighthouse "Use efficient cache lifetimes": the project videos in
+# /public were served with no Cache-Control, so they were re-downloaded on
+# every visit (~2.1 MB+ each).
+
+# Astro fingerprints these filenames on every build, so they're safe to cache
+# forever.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Unhashed media. Cached for a year — if you replace a file in place, rename it
+# (or append ?v=2 at the call site) so returning visitors pick up the new one.
+/lefellic/*
+  Cache-Control: public, max-age=31536000, immutable
+/motivai/*
+  Cache-Control: public, max-age=31536000, immutable
+/persistance/*
+  Cache-Control: public, max-age=31536000, immutable
+/pictures/*
+  Cache-Control: public, max-age=31536000, immutable
+/icons/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/components/CalDrawer.astro
+++ b/src/components/CalDrawer.astro
@@ -214,8 +214,27 @@ const calLink = String(
         }
     });
 
-    // ponytail: preload once so the first CTA click doesn't show Cal's loader.
-    mountCalEmbed();
+    // Mount the Cal embed lazily on the first sign of booking intent (hovering
+    // or keyboard-focusing any CTA) so it's ready by the time the drawer opens,
+    // WITHOUT pulling Cal's ~850 KiB of JS/CSS into every page load. Previously
+    // this mounted eagerly on load, which tanked Performance (the embed renders
+    // a full booking iframe in the hidden dialog for every visitor, even those
+    // who never click). openCalDrawer() still mounts on a direct click (touch /
+    // keyboard / programmatic) as the final fallback.
+    function warmCalEmbed(event) {
+        const target = event.target;
+        if (!(target instanceof Element) || !target.closest("[data-cal-open]"))
+            return;
+
+        mountCalEmbed();
+        document.removeEventListener("pointerover", warmCalEmbed);
+        document.removeEventListener("focusin", warmCalEmbed);
+        document.removeEventListener("touchstart", warmCalEmbed);
+    }
+
+    document.addEventListener("pointerover", warmCalEmbed);
+    document.addEventListener("focusin", warmCalEmbed);
+    document.addEventListener("touchstart", warmCalEmbed, { passive: true });
 </script>
 
 <style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -46,7 +46,7 @@ const links = [
             >
                 william.deazevedopro@gmail.com
             </a>
-            <p class="text-xs text-gray-500">© {year} William De Azevedo</p>
+            <p class="text-xs text-gray-600">© {year} William De Azevedo</p>
         </div>
     </div>
 </footer>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -134,6 +134,7 @@ const displayedTestimonials = temoignages
                                 ]}
                                 data-testimonial-item
                                 aria-hidden={index === 0 ? undefined : "true"}
+                                inert={index === 0 ? undefined : true}
                             >
                                 <div class="testimonial-avatar">
                                     {temoignage.image ? (
@@ -352,6 +353,10 @@ const displayedTestimonials = temoignages
 
                         item.classList.toggle("is-active", isActive);
                         item.setAttribute("aria-hidden", String(!isActive));
+                        // inert removes the hidden testimonial (and its link)
+                        // from the a11y tree AND tab order, so aria-hidden no
+                        // longer wraps a focusable descendant.
+                        item.toggleAttribute("inert", !isActive);
                     });
                 };
 


### PR DESCRIPTION
## Pourquoi le Perf était à 60

Ce n'est pas Astro : le site statique ne pèse quasi rien. Trois greffons tiers plombaient le rapport Lighthouse.

**1. Le widget Cal.com était monté en entier à chaque chargement** *(le vrai coupable)*
`CalDrawer.astro` appelait `mountCalEmbed()` au load → `Cal("inline", …)` rendait l'**iframe de réservation complète** dans le `<dialog>` caché, **pour 100 % des visiteurs**. D'où les lignes cal.com dans presque tous les audits : 409 KiB de JS inutilisé, 88 KiB de CSS, ~850 KiB réseau, plusieurs secondes de CPU, l'API dépréciée (Best Practices), le « Shared Storage API ».

**2. ~13 Mo de `.mp4` non-cachés dans `/public`** (Cache-Control « None ») → re-téléchargés à chaque visite.

**3. GTM** ~174 KiB sur le main-thread (non traité ici — voir plus bas).

## Correctifs

| Fichier | Correctif | Cible Lighthouse |
|---|---|---|
| `CalDrawer.astro` | Cal monté **à la 1ʳᵉ intention** (`pointerover`/`focusin`/`touchstart` sur un CTA `[data-cal-open]`) ; le clic reste le fallback | Perf, Best Practices, unused JS/CSS, network payload |
| `public/_headers` *(nouveau)* | `Cache-Control: public, max-age=31536000, immutable` sur `/_astro`, vidéos, images | « Use efficient cache lifetimes » (~2 122 KiB) |
| `index.astro` | `inert` sur les témoignages inactifs (markup + JS) | A11y « aria-hidden focusable » + Agentic Browsing 1/2 → 2/2 |
| `Footer.astro` | `©` : `text-gray-500` (4,3:1, échoue AA) → `text-gray-600` (~6,2:1) | A11y contraste |

Pour l'utilisateur, Cal reste instantané (warm-up au survol). `bun run build` passe ✅.

## Reste à décider (non inclus — choix de contenu)

- **Ré-encoder les vidéos** (`motivai-landing.mp4` = 5,1 Mo) en H.265/AV1 → le « enormous network payloads — 5 623 KiB » restant.
- **Posters surdimensionnés** (1552×900 affichés en 1056×594, -53 KiB).
- **GTM via `@astrojs/partytown`** (sort les 174 KiB du main-thread).

> Impact **attendu**, pas re-mesuré (pas de relance Lighthouse). Le cache `immutable` sur les `.mp4` non-hashés impose de renommer un fichier (ou `?v=2`) si on le remplace en place — noté dans `_headers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)