### PR TITLE
perf(dot-matrix): use lightweight canvas renderer

### DIFF
--- a/src/components/AboutLogoMatrix.astro
+++ b/src/components/AboutLogoMatrix.astro
@@ -10,280 +10,28 @@ const classes = ["about-logo-matrix", className, classAttribute]
     .join(" ");
 ---
 
-<div class={classes} data-about-logo-matrix aria-hidden="true">
-    <canvas class="about-logo-matrix__canvas"></canvas>
-    <svg class="about-logo-matrix__source" viewBox="0 0 53 30" fill="none">
-        <path d="M53 0L44.985 13.8765L37.0616 0H53Z" />
-        <path d="M35.6656 30L40.8419 21.0452L28.8221 0H18.5282L23.1758 8.12843L23.1724 8.13363L28.302 17.1144L28.3037 17.1109L35.6656 30Z" />
-        <path d="M17.1391 30L22.3137 21.0452L10.2938 0H0L4.64761 8.12843L4.64415 8.13363L9.7738 17.1144L9.77553 17.1109L17.1391 30Z" />
-    </svg>
+<div class={classes} aria-hidden="true">
+    <canvas
+        class="about-logo-matrix__canvas"
+        data-dot-canvas
+        data-dot-color="#ffffff"
+        data-dot-fps="24"
+        data-dot-gap="7"
+        data-dot-max-opacity="0.72"
+        data-dot-min-opacity="0.12"
+        data-dot-pixel-ratio="1"
+        data-dot-size="1"
+        data-dot-speed="0.006"
+    ></canvas>
 </div>
 
 <script>
-    type MatrixState = {
-        destroy: () => void;
-    };
-
-    const windowWithAboutLogoMatrix = window as Window & {
-        __wuiAboutLogoMatrixStates?: Set<MatrixState>;
-    };
-    const activeStates =
-        windowWithAboutLogoMatrix.__wuiAboutLogoMatrixStates ?? new Set<MatrixState>();
-
-    windowWithAboutLogoMatrix.__wuiAboutLogoMatrixStates = activeStates;
-
-    const stateByRoot = new WeakMap<HTMLElement, MatrixState>();
-
-    const initAboutLogoMatrices = () => {
-        document
-            .querySelectorAll<HTMLElement>("[data-about-logo-matrix]")
-            .forEach((root) => {
-                if (
-                    root.dataset.aboutLogoMatrixReady === "true" ||
-                    stateByRoot.has(root)
-                ) {
-                    return;
-                }
-
-                const canvas =
-                    root.querySelector<HTMLCanvasElement>("canvas");
-                const source = root.querySelector<SVGSVGElement>("svg");
-                const context = canvas?.getContext("2d");
-                const probe = document.createElement("canvas").getContext("2d");
-                const staticCanvas = document.createElement("canvas");
-                const staticContext = staticCanvas.getContext("2d");
-
-                if (!canvas || !source || !context || !probe || !staticContext) {
-                    return;
-                }
-
-                root.dataset.aboutLogoMatrixReady = "true";
-
-                const paths = Array.from(source.querySelectorAll("path")).map(
-                    (path) => new Path2D(path.getAttribute("d") ?? ""),
-                );
-                const prefersReducedMotion = window.matchMedia(
-                    "(prefers-reduced-motion: reduce)",
-                ).matches;
-                const randomUnit = (seed: number) => {
-                    const value = Math.sin(seed) * 10000;
-
-                    return value - Math.floor(value);
-                };
-                let dots: Array<{
-                    x: number;
-                    y: number;
-                    size: number;
-                    alpha: number;
-                    phase: number;
-                    speed: number;
-                    interval: number;
-                    pop: number;
-                }> = [];
-                let frame = 0;
-                let isActive = false;
-                let pendingStart = 0;
-                let pendingStartType: "idle" | "timeout" | undefined;
-                let lastRender = 0;
-                let color = "255 255 255";
-                let width = 0;
-                let height = 0;
-                let hasPainted = false;
-
-                const stop = () => {
-                    if (pendingStartType === "idle" && "cancelIdleCallback" in window) {
-                        window.cancelIdleCallback(pendingStart);
-                    } else if (pendingStartType === "timeout") {
-                        window.clearTimeout(pendingStart);
-                    }
-                    pendingStart = 0;
-                    pendingStartType = undefined;
-                    isActive = false;
-
-                    if (frame) {
-                        window.cancelAnimationFrame(frame);
-                        frame = 0;
-                    }
-                };
-
-                const resize = () => {
-                    const rect = root.getBoundingClientRect();
-                    width = rect.width;
-                    height = rect.height;
-                    const ratio = Math.min(window.devicePixelRatio || 1, 1.5);
-                    const gap = width > 720 ? 9 : 7;
-
-                    if (width === 0 || height === 0) return;
-
-                    color =
-                        getComputedStyle(root)
-                            .getPropertyValue("--about-logo-matrix-color")
-                            .trim() || "255 255 255";
-
-                    canvas.width = Math.max(1, Math.floor(width * ratio));
-                    canvas.height = Math.max(1, Math.floor(height * ratio));
-                    staticCanvas.width = canvas.width;
-                    staticCanvas.height = canvas.height;
-                    context.setTransform(ratio, 0, 0, ratio, 0, 0);
-                    staticContext.setTransform(ratio, 0, 0, ratio, 0, 0);
-                    staticContext.clearRect(0, 0, width, height);
-                    dots = [];
-
-                    for (let y = 1; y < height; y += gap) {
-                        for (let x = 1; x < width; x += gap) {
-                            const sourceX = (x / width) * 53;
-                            const sourceY = (y / height) * 30;
-                            const active = paths.some((path) =>
-                                probe.isPointInPath(path, sourceX, sourceY),
-                            );
-                            const size = active ? 1.45 : 0.95;
-                            const alpha = active
-                                ? 0.12 + Math.random() * 0.24
-                                : 0.015 + Math.random() * 0.035;
-                            const dot = {
-                                x,
-                                y,
-                                size,
-                                alpha,
-                                phase: Math.random() * Math.PI * 2,
-                                speed: 0.0018 + Math.random() * 0.0032,
-                                interval: 220 + Math.random() * 620,
-                                pop: active ? 0.28 : 0.16,
-                            };
-
-                            if (!active) {
-                                staticContext.fillStyle = `rgb(${color} / ${alpha})`;
-                                staticContext.fillRect(x, y, size, size);
-                                continue;
-                            }
-
-                            dots.push(dot);
-                        }
-                    }
-                };
-
-                const render = (time = 0) => {
-                    if (width === 0 || height === 0) return;
-
-                    context.clearRect(0, 0, width, height);
-                    context.drawImage(staticCanvas, 0, 0, width, height);
-
-                    dots.forEach((dot) => {
-                        const wave = prefersReducedMotion
-                            ? 0
-                            : (Math.sin(time * dot.speed + dot.phase) + 1) / 2;
-                        const tick = Math.floor(time / dot.interval);
-                        const blink =
-                            !prefersReducedMotion &&
-                            randomUnit(dot.phase + tick * 12.9898) > 0.8
-                                ? dot.pop
-                                : 0;
-                        const alpha = dot.alpha * (0.62 + wave * 0.22 + blink);
-
-                        context.fillStyle = `rgb(${color} / ${alpha})`;
-                        context.fillRect(dot.x, dot.y, dot.size, dot.size);
-                    });
-                };
-
-                const tick = (time = 0) => {
-                    frame = 0;
-
-                    if (time - lastRender > 33) {
-                        lastRender = time;
-                        render(time);
-                    }
-
-                    if (isActive) frame = window.requestAnimationFrame(tick);
-                };
-
-                const activate = () => {
-                    pendingStart = 0;
-                    pendingStartType = undefined;
-                    if (prefersReducedMotion || isActive) return;
-
-                    isActive = true;
-                    frame = window.requestAnimationFrame(tick);
-                };
-
-                const start = () => {
-                    if (prefersReducedMotion || isActive || pendingStartType) {
-                        return;
-                    }
-
-                    if ("requestIdleCallback" in window) {
-                        pendingStartType = "idle";
-                        pendingStart = window.requestIdleCallback(activate, {
-                            timeout: 1200,
-                        });
-                    } else {
-                        pendingStartType = "timeout";
-                        pendingStart = window.setTimeout(activate, 420);
-                    }
-                };
-                const paint = () => {
-                    if (hasPainted) return;
-
-                    hasPainted = true;
-                    resizeObserver.observe(root);
-                    resize();
-                    render(performance.now());
-                };
-
-                const resizeObserver = new ResizeObserver(() => {
-                    resize();
-                    render(performance.now());
-                });
-                const visibilityObserver = new IntersectionObserver(
-                    ([entry]) => {
-                        if (entry?.isIntersecting) {
-                            paint();
-                            start();
-                        } else {
-                            stop();
-                        }
-                    },
-                    { rootMargin: "320px" },
-                );
-                const state = {
-                    destroy: () => {
-                        stop();
-                        resizeObserver.disconnect();
-                        visibilityObserver.disconnect();
-                        activeStates.delete(state);
-                        stateByRoot.delete(root);
-                        delete root.dataset.aboutLogoMatrixReady;
-                    },
-                };
-
-                activeStates.add(state);
-                stateByRoot.set(root, state);
-
-                if ("IntersectionObserver" in window) {
-                    visibilityObserver.observe(root);
-                } else {
-                    paint();
-                    start();
-                }
-            });
-    };
-    const resetAboutLogoMatrices = () => {
-        activeStates.forEach((state) => state.destroy());
-        activeStates.clear();
-    };
-    const listenerKey = "__wuiAboutLogoMatrixListenerReady";
-
-    initAboutLogoMatrices();
-
-    if (!(listenerKey in window)) {
-        Object.defineProperty(window, listenerKey, { value: true });
-        document.addEventListener("astro:before-swap", resetAboutLogoMatrices);
-        document.addEventListener("astro:page-load", initAboutLogoMatrices);
-    }
+    import "../scripts/dotCanvas";
 </script>
 
 <style>
     .about-logo-matrix {
-        --about-logo-matrix-color: 255 255 255;
+        --about-logo-matrix-mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2053%2030%22%3E%3Cpath%20fill%3D%22white%22%20d%3D%22M53%200L44.985%2013.8765L37.0616%200H53Z%22%2F%3E%3Cpath%20fill%3D%22white%22%20d%3D%22M35.6656%2030L40.8419%2021.0452L28.8221%200H18.5282L23.1758%208.12843L23.1724%208.13363L28.302%2017.1144L28.3037%2017.1109L35.6656%2030Z%22%2F%3E%3Cpath%20fill%3D%22white%22%20d%3D%22M17.1391%2030L22.3137%2021.0452L10.2938%200H0L4.64761%208.12843L4.64415%208.13363L9.7738%2017.1144L9.77553%2017.1109L17.1391%2030Z%22%2F%3E%3C%2Fsvg%3E");
 
         aspect-ratio: 53 / 30;
         display: block;
@@ -301,11 +49,15 @@ const classes = ["about-logo-matrix", className, classAttribute]
     .about-logo-matrix__canvas {
         display: block;
         height: 100%;
+        -webkit-mask-image: var(--about-logo-matrix-mask);
+        mask-image: var(--about-logo-matrix-mask);
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: contain;
+        mask-size: contain;
         width: 100%;
-    }
-
-    .about-logo-matrix__source {
-        display: none;
     }
 
     @media (max-width: 767px) {

--- a/src/components/HeroDotMatrix.astro
+++ b/src/components/HeroDotMatrix.astro
@@ -1,338 +1,50 @@
-<div class="hero-dot-matrix" data-hero-dot-matrix>
-    <canvas class="hero-dot-matrix__canvas" aria-hidden="true"></canvas>
-<svg class="hero-dot-matrix__source" viewBox="0 0 1372 59" fill="none" aria-hidden="true">
-    <defs>
-        <pattern
-            id="hero-dot-matrix-base"
-            width="8"
-            height="8"
-            patternUnits="userSpaceOnUse"
-        >
-            <circle cx="1" cy="1" r="0.72" fill="#111827" opacity="0.08" />
-        </pattern>
-        <pattern
-            id="hero-dot-matrix-ink"
-            width="6"
-            height="6"
-            patternUnits="userSpaceOnUse"
-        >
-            <circle cx="1" cy="1" r="0.9" fill="#111827" opacity="0.72" />
-        </pattern>
-        <mask
-            id="hero-dot-matrix-mask"
-            maskUnits="userSpaceOnUse"
-            x="0"
-            y="0"
-            width="1372"
-            height="59"
-        >
-            <rect width="1372" height="59" fill="black" />
-            <g fill="white">
-                <path d="M105 0L89.1213 27.2905L73.424 0H105Z" />
-                <path d="M70.6583 59L80.9132 41.3889L57.1003 0H36.7068L45.9144 15.9859L45.9075 15.9961L56.07 33.6583L56.0735 33.6515L70.6583 59Z" />
-                <path d="M33.9549 59L44.2064 41.3889L20.3935 0H0L9.20752 15.9859L9.20068 15.9961L19.3632 33.6583L19.3666 33.6515L33.9549 59Z" />
-                <path d="M781 0L765.121 27.2905L749.424 0H781Z" />
-                <path d="M746.658 59L756.913 41.3889L733.1 0H712.707L721.914 15.9859L721.908 15.9961L732.07 33.6583L732.073 33.6515L746.658 59Z" />
-                <path d="M709.955 59L720.206 41.3889L696.393 0H676L685.208 15.9859L685.201 15.9961L695.363 33.6583L695.367 33.6515L709.955 59Z" />
-                <path d="M443 0L427.121 27.2905L411.424 0H443Z" />
-                <path d="M408.658 59L418.913 41.3889L395.1 0H374.707L383.914 15.9859L383.908 15.9961L394.07 33.6583L394.073 33.6515L408.658 59Z" />
-                <path d="M371.955 59L382.206 41.3889L358.393 0H338L347.208 15.9859L347.201 15.9961L357.363 33.6583L357.367 33.6515L371.955 59Z" />
-                <path d="M1119 0L1103.12 27.2905L1087.42 0H1119Z" />
-                <path d="M1084.66 59L1094.91 41.3889L1071.1 0H1050.71L1059.91 15.9859L1059.91 15.9961L1070.07 33.6583L1070.07 33.6515L1084.66 59Z" />
-                <path d="M1047.95 59L1058.21 41.3889L1034.39 0H1014L1023.21 15.9859L1023.2 15.9961L1033.36 33.6583L1033.37 33.6515L1047.95 59Z" />
-                <path d="M274 0L258.121 27.2905L242.424 0H274Z" />
-                <path d="M239.658 59L249.913 41.3889L226.1 0H205.707L214.914 15.9859L214.908 15.9961L225.07 33.6583L225.073 33.6515L239.658 59Z" />
-                <path d="M202.955 59L213.206 41.3889L189.393 0H169L178.208 15.9859L178.201 15.9961L188.363 33.6583L188.367 33.6515L202.955 59Z" />
-                <path d="M950 0L934.121 27.2905L918.424 0H950Z" />
-                <path d="M915.658 59L925.913 41.3889L902.1 0H881.707L890.914 15.9859L890.908 15.9961L901.07 33.6583L901.073 33.6515L915.658 59Z" />
-                <path d="M878.955 59L889.206 41.3889L865.393 0H845L854.208 15.9859L854.201 15.9961L864.363 33.6583L864.367 33.6515L878.955 59Z" />
-                <path d="M612 0L596.121 27.2905L580.424 0H612Z" />
-                <path d="M577.658 59L587.913 41.3889L564.1 0H543.707L552.914 15.9859L552.908 15.9961L563.07 33.6583L563.073 33.6515L577.658 59Z" />
-                <path d="M540.955 59L551.206 41.3889L527.393 0H507L516.208 15.9859L516.201 15.9961L526.363 33.6583L526.367 33.6515L540.955 59Z" />
-                <path d="M1288 0L1272.12 27.2905L1256.42 0H1288Z" />
-                <path d="M1253.66 59L1263.91 41.3889L1240.1 0H1219.71L1228.91 15.9859L1228.91 15.9961L1239.07 33.6583L1239.07 33.6515L1253.66 59Z" />
-                <path d="M1216.95 59L1227.21 41.3889L1203.39 0H1183L1192.21 15.9859L1192.2 15.9961L1202.36 33.6583L1202.37 33.6515L1216.95 59Z" />
-                <path d="M84 59L99.8787 31.7095L115.576 59L84 59Z" />
-                <path d="M118.342 -6.17715e-06L108.087 17.6111L131.9 59L152.293 59L143.086 43.0141L143.092 43.0039L132.93 25.3417L132.927 25.3485L118.342 -6.17715e-06Z" />
-                <path d="M155.045 -2.96843e-06L144.794 17.6111L168.607 59L189 59L179.792 43.0141L179.799 43.0039L169.637 25.3417L169.633 25.3485L155.045 -2.96843e-06Z" />
-                <path d="M760 59L775.879 31.7095L791.576 59L760 59Z" />
-                <path d="M794.342 -6.17715e-06L784.087 17.6111L807.9 59L828.293 59L819.086 43.0141L819.092 43.0039L808.93 25.3417L808.927 25.3485L794.342 -6.17715e-06Z" />
-                <path d="M831.045 -2.96843e-06L820.794 17.6111L844.607 59L865 59L855.792 43.0141L855.799 43.0039L845.637 25.3417L845.633 25.3485L831.045 -2.96843e-06Z" />
-                <path d="M422 59L437.879 31.7095L453.576 59L422 59Z" />
-                <path d="M456.342 -6.17715e-06L446.087 17.6111L469.9 59L490.293 59L481.086 43.0141L481.092 43.0039L470.93 25.3417L470.927 25.3485L456.342 -6.17715e-06Z" />
-                <path d="M493.045 -2.96843e-06L482.794 17.6111L506.607 59L527 59L517.792 43.0141L517.799 43.0039L507.637 25.3417L507.633 25.3485L493.045 -2.96843e-06Z" />
-                <path d="M1098 59L1113.88 31.7095L1129.58 59L1098 59Z" />
-                <path d="M1132.34 -6.17715e-06L1122.09 17.6111L1145.9 59L1166.29 59L1157.09 43.0141L1157.09 43.0039L1146.93 25.3417L1146.93 25.3485L1132.34 -6.17715e-06Z" />
-                <path d="M1169.05 -2.96843e-06L1158.79 17.6111L1182.61 59L1203 59L1193.79 43.0141L1193.8 43.0039L1183.64 25.3417L1183.63 25.3485L1169.05 -2.96843e-06Z" />
-                <path d="M253 59L268.879 31.7095L284.576 59L253 59Z" />
-                <path d="M287.342 -6.17715e-06L277.087 17.6111L300.9 59L321.293 59L312.086 43.0141L312.092 43.0039L301.93 25.3417L301.927 25.3485L287.342 -6.17715e-06Z" />
-                <path d="M324.045 -2.96843e-06L313.794 17.6111L337.607 59L358 59L348.792 43.0141L348.799 43.0039L338.637 25.3417L338.633 25.3485L324.045 -2.96843e-06Z" />
-                <path d="M929 59L944.879 31.7095L960.576 59L929 59Z" />
-                <path d="M963.342 -6.17715e-06L953.087 17.6111L976.9 59L997.293 59L988.086 43.0141L988.092 43.0039L977.93 25.3417L977.927 25.3485L963.342 -6.17715e-06Z" />
-                <path d="M1000.05 -2.96843e-06L989.794 17.6111L1013.61 59L1034 59L1024.79 43.0141L1024.8 43.0039L1014.64 25.3417L1014.63 25.3485L1000.05 -2.96843e-06Z" />
-                <path d="M591 59L606.879 31.7095L622.576 59L591 59Z" />
-                <path d="M625.342 -6.17715e-06L615.087 17.6111L638.9 59L659.293 59L650.086 43.0141L650.092 43.0039L639.93 25.3417L639.927 25.3485L625.342 -6.17715e-06Z" />
-                <path d="M662.045 -2.96843e-06L651.794 17.6111L675.607 59L696 59L686.792 43.0141L686.799 43.0039L676.637 25.3417L676.633 25.3485L662.045 -2.96843e-06Z" />
-                <path d="M1267 59L1282.88 31.7095L1298.58 59L1267 59Z" />
-                <path d="M1301.34 -6.17715e-06L1291.09 17.6111L1314.9 59L1335.29 59L1326.09 43.0141L1326.09 43.0039L1315.93 25.3417L1315.93 25.3485L1301.34 -6.17715e-06Z" />
-                <path d="M1338.05 -2.96843e-06L1327.79 17.6111L1351.61 59L1372 59L1362.79 43.0141L1362.8 43.0039L1352.64 25.3417L1352.63 25.3485L1338.05 -2.96843e-06Z" />
-            </g>
-        </mask>
-    </defs>
-
-    <rect width="1372" height="59" fill="url(#hero-dot-matrix-base)" />
-    <rect
-        width="1372"
-        height="59"
-        fill="url(#hero-dot-matrix-ink)"
-        mask="url(#hero-dot-matrix-mask)"
-    />
-</svg>
+<div class="hero-dot-matrix" aria-hidden="true">
+    <canvas
+        class="hero-dot-matrix__canvas"
+        data-dot-canvas
+        data-dot-color="#111827"
+        data-dot-fps="24"
+        data-dot-gap="5"
+        data-dot-max-opacity="0.5"
+        data-dot-min-opacity="0.04"
+        data-dot-pixel-ratio="1"
+        data-dot-size="1"
+        data-dot-speed="0.006"
+    ></canvas>
 </div>
 
 <script>
-    type MatrixState = {
-        destroy: () => void;
-    };
-
-    const windowWithHeroDotMatrix = window as Window & {
-        __wuiHeroDotMatrixStates?: Set<MatrixState>;
-    };
-    const activeStates =
-        windowWithHeroDotMatrix.__wuiHeroDotMatrixStates ?? new Set<MatrixState>();
-
-    windowWithHeroDotMatrix.__wuiHeroDotMatrixStates = activeStates;
-
-    const stateByRoot = new WeakMap<HTMLElement, MatrixState>();
-
-    const initHeroDotMatrices = () => {
-        document
-            .querySelectorAll<HTMLElement>("[data-hero-dot-matrix]")
-            .forEach((root) => {
-                if (
-                    root.dataset.heroDotMatrixReady === "true" ||
-                    stateByRoot.has(root)
-                ) {
-                    return;
-                }
-
-                const canvas =
-                    root.querySelector<HTMLCanvasElement>("canvas");
-                const source = root.querySelector<SVGSVGElement>("svg");
-                const context = canvas?.getContext("2d");
-
-                if (!canvas || !source || !context) return;
-
-                root.dataset.heroDotMatrixReady = "true";
-
-                const paths = Array.from(source.querySelectorAll("path")).map(
-                    (path) => new Path2D(path.getAttribute("d") ?? ""),
-                );
-                const probe = document.createElement("canvas").getContext("2d");
-                const prefersReducedMotion = window.matchMedia(
-                    "(prefers-reduced-motion: reduce)",
-                ).matches;
-                let dots: Array<{
-                    x: number;
-                    y: number;
-                    size: number;
-                    alpha: number;
-                    phase: number;
-                    speed: number;
-                    interval: number;
-                    pop: number;
-                }> = [];
-                let frame = 0;
-                let isActive = false;
-                let pendingStart = 0;
-                let pendingStartType: "idle" | "timeout" | undefined;
-                let lastRender = 0;
-                let width = 0;
-                let height = 0;
-                const randomUnit = (seed: number) => {
-                    const value = Math.sin(seed) * 10000;
-                    return value - Math.floor(value);
-                };
-                const stop = () => {
-                    if (pendingStartType === "idle" && "cancelIdleCallback" in window) {
-                        window.cancelIdleCallback(pendingStart);
-                    } else if (pendingStartType === "timeout") {
-                        window.clearTimeout(pendingStart);
-                    }
-                    pendingStart = 0;
-                    pendingStartType = undefined;
-                    isActive = false;
-
-                    if (frame) {
-                        window.cancelAnimationFrame(frame);
-                        frame = 0;
-                    }
-                };
-
-                const resize = () => {
-                    const rect = root.getBoundingClientRect();
-                    width = rect.width;
-                    height = rect.height;
-                    const ratio = Math.min(window.devicePixelRatio || 1, 2);
-                    const gap = width > 720 ? 5 : 4;
-
-                    if (width === 0 || height === 0) return;
-
-                    canvas.width = Math.max(1, Math.floor(width * ratio));
-                    canvas.height = Math.max(1, Math.floor(height * ratio));
-                    context.setTransform(ratio, 0, 0, ratio, 0, 0);
-
-                    dots = [];
-
-                    for (let y = 1; y < height; y += gap) {
-                        for (let x = 1; x < width; x += gap) {
-                            const sourceX = (x / width) * 1372;
-                            const sourceY = (y / height) * 59;
-                            const active =
-                                probe &&
-                                paths.some((path) =>
-                                    probe.isPointInPath(path, sourceX, sourceY),
-                                );
-
-                            dots.push({
-                                x,
-                                y,
-                                size: active ? 1.35 : 0.95,
-                                alpha: active
-                                    ? 0.32 + Math.random() * 0.44
-                                    : 0.035 + Math.random() * 0.08,
-                                phase: Math.random() * Math.PI * 2,
-                                speed: 0.002 + Math.random() * 0.004,
-                                interval: 180 + Math.random() * 520,
-                                pop: active ? 0.26 : 0.18,
-                            });
-                        }
-                    }
-                };
-
-                const render = (time = 0) => {
-                    if (width === 0 || height === 0) return;
-
-                    context.clearRect(0, 0, width, height);
-
-                    dots.forEach((dot) => {
-                        const wave = prefersReducedMotion
-                            ? 0
-                            : (Math.sin(time * dot.speed + dot.phase) + 1) / 2;
-                        const tick = Math.floor(time / dot.interval);
-                        const blink =
-                            !prefersReducedMotion &&
-                            randomUnit(dot.phase + tick * 12.9898) > 0.78
-                                ? dot.pop
-                                : 0;
-                        const alpha = dot.alpha * (0.58 + wave * 0.22 + blink);
-
-                        context.fillStyle = `rgb(17 24 39 / ${alpha})`;
-                        context.fillRect(dot.x, dot.y, dot.size, dot.size);
-                    });
-                };
-
-                const tick = (time = 0) => {
-                    frame = 0;
-
-                    if (time - lastRender > 33) {
-                        lastRender = time;
-                        render(time);
-                    }
-
-                    if (isActive) frame = window.requestAnimationFrame(tick);
-                };
-
-                const activate = () => {
-                    pendingStart = 0;
-                    pendingStartType = undefined;
-                    if (prefersReducedMotion || isActive) return;
-
-                    isActive = true;
-                    frame = window.requestAnimationFrame(tick);
-                };
-
-                const start = () => {
-                    if (prefersReducedMotion || isActive || pendingStartType) {
-                        return;
-                    }
-
-                    if ("requestIdleCallback" in window) {
-                        pendingStartType = "idle";
-                        pendingStart = window.requestIdleCallback(activate, {
-                            timeout: 1200,
-                        });
-                    } else {
-                        pendingStartType = "timeout";
-                        pendingStart = window.setTimeout(activate, 420);
-                    }
-                };
-
-                const resizeObserver = new ResizeObserver(() => {
-                    resize();
-                    render(performance.now());
-                });
-                const visibilityObserver = new IntersectionObserver(
-                    ([entry]) => {
-                        if (entry?.isIntersecting) {
-                            start();
-                        } else {
-                            stop();
-                        }
-                    },
-                    { rootMargin: "160px" },
-                );
-                const state = {
-                    destroy: () => {
-                        stop();
-                        resizeObserver.disconnect();
-                        visibilityObserver.disconnect();
-                        activeStates.delete(state);
-                        stateByRoot.delete(root);
-                        delete root.dataset.heroDotMatrixReady;
-                    },
-                };
-
-                activeStates.add(state);
-                stateByRoot.set(root, state);
-                resizeObserver.observe(root);
-                resize();
-                render();
-
-                if (!prefersReducedMotion) visibilityObserver.observe(root);
-            });
-    };
-    const resetHeroDotMatrices = () => {
-        activeStates.forEach((state) => state.destroy());
-        activeStates.clear();
-    };
-    const listenerKey = "__wuiHeroDotMatrixListenerReady";
-
-    initHeroDotMatrices();
-
-    if (!(listenerKey in window)) {
-        Object.defineProperty(window, listenerKey, { value: true });
-        document.addEventListener("astro:before-swap", resetHeroDotMatrices);
-        document.addEventListener("astro:page-load", initHeroDotMatrices);
-    }
+    import "../scripts/dotCanvas";
 </script>
 
 <style>
     .hero-dot-matrix {
+        aspect-ratio: 1372 / 59;
         display: block;
         margin: -0.25rem auto 0;
         max-width: 54rem;
-        aspect-ratio: 1372 / 59;
+        opacity: 0.78;
+        pointer-events: none;
         width: 100%;
+        -webkit-mask-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            #000 14%,
+            #000 86%,
+            transparent 100%
+        );
+        mask-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            #000 14%,
+            #000 86%,
+            transparent 100%
+        );
     }
 
     .hero-dot-matrix__canvas {
         display: block;
         height: 100%;
         width: 100%;
-    }
-
-    .hero-dot-matrix__source {
-        display: none;
     }
 </style>

--- a/src/scripts/dotCanvas.ts
+++ b/src/scripts/dotCanvas.ts
@@ -1,0 +1,256 @@
+type DotPoint = {
+  direction: -1 | 1;
+  opacity: number;
+  speed: number;
+  x: number;
+  y: number;
+};
+
+type DotCanvasState = {
+  buckets: DotPoint[][];
+  canvas: HTMLCanvasElement;
+  color: string;
+  context: CanvasRenderingContext2D;
+  dotSize: number;
+  frame?: number;
+  fps: number;
+  height: number;
+  lastPaint: number;
+  maxOpacity: number;
+  minOpacity: number;
+  points: DotPoint[];
+  reducedMotion: boolean;
+  resizeObserver?: ResizeObserver;
+  speed: number;
+  visible: boolean;
+  visibilityObserver?: IntersectionObserver;
+  width: number;
+};
+
+const windowWithDotCanvas = window as Window & {
+  __wuiDotCanvasLifecycleReady?: boolean;
+  __wuiDotCanvasStates?: Set<DotCanvasState>;
+};
+const activeDotCanvasStates =
+  windowWithDotCanvas.__wuiDotCanvasStates ?? new Set<DotCanvasState>();
+windowWithDotCanvas.__wuiDotCanvasStates = activeDotCanvasStates;
+
+const dotCanvasStateByCanvas = new WeakMap<HTMLCanvasElement, DotCanvasState>();
+
+const parseNumber = (value: string | undefined, fallback: number) => {
+  const parsed = Number.parseFloat(value ?? "");
+
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const resizeDotCanvas = (state: DotCanvasState) => {
+  const { canvas } = state;
+  const rect = canvas.getBoundingClientRect();
+  const ratio = Math.min(
+    window.devicePixelRatio || 1,
+    parseNumber(canvas.dataset.dotPixelRatio, 1.25)
+  );
+  const width = Math.max(1, Math.round(rect.width * ratio));
+  const height = Math.max(1, Math.round(rect.height * ratio));
+  const dotSize = Math.max(
+    1,
+    Math.round(parseNumber(canvas.dataset.dotSize, 1) * ratio)
+  );
+  const gap = Math.max(
+    1,
+    Math.round(parseNumber(canvas.dataset.dotGap, 7) * ratio)
+  );
+  const step = dotSize + gap;
+  const minOpacity = parseNumber(canvas.dataset.dotMinOpacity, 0.04);
+  const maxOpacity = parseNumber(canvas.dataset.dotMaxOpacity, 0.48);
+
+  canvas.width = width;
+  canvas.height = height;
+  state.width = width;
+  state.height = height;
+  state.dotSize = dotSize;
+  state.minOpacity = minOpacity;
+  state.maxOpacity = maxOpacity;
+  state.color = canvas.dataset.dotColor || "#111827";
+  state.fps = parseNumber(canvas.dataset.dotFps, 24);
+  state.speed = parseNumber(canvas.dataset.dotSpeed, 0.006);
+  state.points = [];
+
+  for (let y = 0; y < height; y += step) {
+    for (let x = 0; x < width; x += step) {
+      state.points.push({
+        direction: Math.random() > 0.5 ? 1 : -1,
+        opacity: minOpacity + Math.random() * (maxOpacity - minOpacity),
+        speed: state.speed * (0.45 + Math.random()),
+        x,
+        y,
+      });
+    }
+  }
+};
+
+const paintDotCanvas = (state: DotCanvasState, animate: boolean) => {
+  const { buckets, context, dotSize, height, maxOpacity, minOpacity, width } =
+    state;
+
+  context.clearRect(0, 0, width, height);
+  context.fillStyle = state.color;
+  buckets.forEach((bucket) => {
+    bucket.length = 0;
+  });
+
+  state.points.forEach((point) => {
+    if (animate) {
+      point.opacity += point.speed * point.direction;
+
+      if (point.opacity >= maxOpacity || point.opacity <= minOpacity) {
+        point.opacity = Math.min(
+          maxOpacity,
+          Math.max(minOpacity, point.opacity)
+        );
+        point.direction *= -1;
+      }
+    }
+
+    buckets[Math.round(point.opacity * 20)]?.push(point);
+  });
+
+  buckets.forEach((bucket, index) => {
+    if (bucket.length === 0) return;
+
+    context.globalAlpha = index / 20;
+    bucket.forEach((point) => {
+      context.fillRect(point.x, point.y, dotSize, dotSize);
+    });
+  });
+  context.globalAlpha = 1;
+};
+
+const stopDotCanvas = (state: DotCanvasState) => {
+  if (!state.frame) return;
+
+  window.cancelAnimationFrame(state.frame);
+  state.frame = undefined;
+};
+
+const renderDotCanvas = (state: DotCanvasState, time: number) => {
+  if (!state.visible) {
+    stopDotCanvas(state);
+    return;
+  }
+
+  if (time - state.lastPaint >= 1000 / state.fps) {
+    paintDotCanvas(state, true);
+    state.lastPaint = time;
+  }
+
+  state.frame = window.requestAnimationFrame((nextTime) =>
+    renderDotCanvas(state, nextTime)
+  );
+};
+
+const startDotCanvas = (state: DotCanvasState) => {
+  if (state.reducedMotion) {
+    paintDotCanvas(state, false);
+    return;
+  }
+
+  if (state.frame) return;
+
+  state.frame = window.requestAnimationFrame((time) =>
+    renderDotCanvas(state, time)
+  );
+};
+
+const destroyDotCanvas = (state: DotCanvasState) => {
+  stopDotCanvas(state);
+  state.resizeObserver?.disconnect();
+  state.visibilityObserver?.disconnect();
+  dotCanvasStateByCanvas.delete(state.canvas);
+  activeDotCanvasStates.delete(state);
+  delete state.canvas.dataset.dotCanvasReady;
+};
+
+const bindDotCanvas = (canvas: HTMLCanvasElement) => {
+  if (
+    dotCanvasStateByCanvas.has(canvas) ||
+    canvas.dataset.dotCanvasReady === "true"
+  ) {
+    return;
+  }
+
+  const context = canvas.getContext("2d", { alpha: true });
+
+  if (!context) return;
+
+  const reducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  const state: DotCanvasState = {
+    buckets: Array.from({ length: 21 }, () => []),
+    canvas,
+    color: canvas.dataset.dotColor || "#111827",
+    context,
+    dotSize: 1,
+    fps: 24,
+    height: 1,
+    lastPaint: 0,
+    maxOpacity: 0.48,
+    minOpacity: 0.04,
+    points: [],
+    reducedMotion,
+    speed: 0.006,
+    visible: false,
+    width: 1,
+  };
+
+  canvas.dataset.dotCanvasReady = "true";
+  dotCanvasStateByCanvas.set(canvas, state);
+  activeDotCanvasStates.add(state);
+  resizeDotCanvas(state);
+  paintDotCanvas(state, false);
+
+  state.resizeObserver = new ResizeObserver(() => {
+    resizeDotCanvas(state);
+    paintDotCanvas(state, false);
+  });
+  state.resizeObserver.observe(canvas);
+
+  const setVisible = (visible: boolean) => {
+    state.visible = visible;
+
+    if (visible) {
+      startDotCanvas(state);
+    } else {
+      stopDotCanvas(state);
+    }
+  };
+
+  if ("IntersectionObserver" in window) {
+    state.visibilityObserver = new IntersectionObserver(
+      (entries) => setVisible(entries[0]?.isIntersecting ?? false),
+      { rootMargin: "80px 0px" }
+    );
+    state.visibilityObserver.observe(canvas);
+  } else {
+    setVisible(true);
+  }
+};
+
+const initDotCanvases = () => {
+  document
+    .querySelectorAll<HTMLCanvasElement>("canvas[data-dot-canvas]")
+    .forEach(bindDotCanvas);
+};
+
+const resetDotCanvases = () => {
+  Array.from(activeDotCanvasStates).forEach(destroyDotCanvas);
+};
+
+initDotCanvases();
+
+if (windowWithDotCanvas.__wuiDotCanvasLifecycleReady !== true) {
+  windowWithDotCanvas.__wuiDotCanvasLifecycleReady = true;
+  document.addEventListener("astro:before-swap", resetDotCanvases);
+  document.addEventListener("astro:page-load", initDotCanvases);
+}


### PR DESCRIPTION
## Summary
- replace the SVG-only dot matrices with lightweight Pulsor-style canvas renderers
- share one bounded dot canvas script with viewport pause and capped pixel ratio
- keep the About logo shape through a CSS mask instead of JS path checks

## Checks
- bun run lint
- bun run format:check
- bun run build