### PR TITLE
fix(site): smooth project anchor scroll

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -248,7 +248,14 @@ body {
     @apply bg-background text-foreground;
   }
   html {
+    scroll-behavior: smooth;
     @apply font-sans;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
   }
 }
 


### PR DESCRIPTION
## Ce qui change

- Active le scroll smooth natif pour les ancres de page.
- Conserve un scroll instantane quand l'utilisateur prefere reduire les animations.

## Pourquoi

Le lien hero vers `#projects` pointait deja vers la bonne section, mais le navigateur scrollait sans transition.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run build`