### PR TITLE
fix(animations): clear mobile blur after reveals

### DIFF
--- a/src/components/AboutCallout.astro
+++ b/src/components/AboutCallout.astro
@@ -28,7 +28,7 @@ const aboutPoints = [
 <section class="relative left-1/2 isolate w-[calc(100dvw-1rem)] -translate-x-1/2 overflow-hidden rounded-2xl bg-coffee-300 py-14 sm:w-[calc(100dvw-2rem)] sm:py-24 md:rounded-3xl md:py-28">
     <AboutLogoMatrix />
     <div class="relative z-10 mx-auto flex max-w-5xl flex-col gap-10 px-4 sm:gap-14 sm:px-8 md:gap-16">
-        <h2 class="mx-auto flex max-w-4xl flex-wrap justify-center gap-x-[0.18em] text-center text-3xl font-medium leading-tighter tracking-[-4%] text-snow-50 sm:text-4xl md:text-6xl">
+        <h2 class="mx-auto flex max-w-4xl flex-wrap justify-center gap-x-[0.18em] text-center text-3xl font-medium leading-tighter tracking-normal text-snow-50 sm:text-4xl md:text-6xl">
             {
                 titleWords.map((word, index) => {
                     const cleanWord = word.replace("\u00A0", " ");
@@ -194,7 +194,7 @@ const aboutPoints = [
 <style>
     .about-callout-title-word {
         animation: about-callout-title-word 1100ms cubic-bezier(0.16, 1, 0.3, 1)
-            both;
+            backwards;
         animation-delay: calc(var(--about-callout-word-index, 0) * 65ms);
         display: inline-block;
     }

--- a/src/components/animations/FadeReveal.astro
+++ b/src/components/animations/FadeReveal.astro
@@ -47,7 +47,7 @@ const {
 <style>
     .fade-reveal {
         animation: fade-reveal 650ms cubic-bezier(0.2, 0, 0, 1)
-            var(--fade-delay, 0s) both;
+            var(--fade-delay, 0s) backwards;
     }
 
     @keyframes fade-reveal {

--- a/src/components/animations/FadeRevealOnScroll.astro
+++ b/src/components/animations/FadeRevealOnScroll.astro
@@ -72,10 +72,19 @@ const {
         will-change: auto;
     }
 
+    .fade-reveal-on-scroll.is-reveal-complete {
+        filter: none;
+        opacity: 1;
+        transform: none;
+        transition: none;
+        will-change: auto;
+    }
+
     @media (scripting: none), (prefers-reduced-motion: reduce) {
         .fade-reveal-on-scroll,
         .fade-reveal-on-scroll.is-reveal-ready,
-        .fade-reveal-on-scroll.is-reveal-ready.is-visible {
+        .fade-reveal-on-scroll.is-reveal-ready.is-visible,
+        .fade-reveal-on-scroll.is-reveal-complete {
             filter: none;
             opacity: 1;
             transform: none;

--- a/src/components/articles/ArticleFilters.tsx
+++ b/src/components/articles/ArticleFilters.tsx
@@ -73,6 +73,9 @@ function FilterSelect({
   options,
   value,
 }: FilterSelectProps) {
+  const selectedLabel =
+    options.find((option) => option.value === value)?.label ?? label;
+
   return (
     <div>
       <label className="sr-only" htmlFor={id}>
@@ -80,7 +83,7 @@ function FilterSelect({
       </label>
       <Select.Root onValueChange={onValueChange} value={value}>
         <Select.Trigger className={filterTriggerClass} id={id}>
-          <Select.Value />
+          <span className="truncate">{selectedLabel}</span>
           <Select.Icon className="text-gray-400">
             <ChevronIcon />
           </Select.Icon>

--- a/src/components/articles/ArticleFilters.tsx
+++ b/src/components/articles/ArticleFilters.tsx
@@ -83,7 +83,7 @@ function FilterSelect({
       </label>
       <Select.Root onValueChange={onValueChange} value={value}>
         <Select.Trigger className={filterTriggerClass} id={id}>
-          <span className="truncate">{selectedLabel}</span>
+          <span className="min-w-0 flex-1 truncate">{selectedLabel}</span>
           <Select.Icon className="text-gray-400">
             <ChevronIcon />
           </Select.Icon>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -12,7 +12,7 @@ import Layout from "@/layout/Layout.astro";
             <p class="text-sm font-light text-blue-500">Erreur 404</p>
         </FadeReveal>
         <FadeReveal delay={0.2}>
-            <h1 class="text-4xl font-medium tracking-[-4%] text-gray-900 sm:text-5xl">
+            <h1 class="text-4xl font-medium tracking-normal text-gray-900 sm:text-5xl">
                 Cette page n'existe pas
             </h1>
         </FadeReveal>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -66,7 +66,7 @@ const pictures = [
 >
     <div class="mx-auto flex w-full max-w-5xl flex-col gap-12 px-4 pb-16 sm:gap-16 sm:px-4 sm:pb-20">
         <section class="flex flex-col gap-6">
-            <h1 class="flex max-w-full flex-wrap justify-center gap-x-[0.18em] text-center text-4xl font-medium leading-tighter tracking-[-4%] text-gray-900 sm:text-6xl md:text-7xl">
+            <h1 class="flex max-w-full flex-wrap justify-center gap-x-[0.18em] text-center text-4xl font-medium leading-tighter tracking-normal text-gray-900 sm:text-6xl md:text-7xl">
                 {
                     aboutHeroTitleWords.map((word, index) => (
                         <span
@@ -150,7 +150,7 @@ const pictures = [
 <style>
     .about-hero-title-word {
         animation: about-hero-title-word 1100ms cubic-bezier(0.16, 1, 0.3, 1)
-            both;
+            backwards;
         animation-delay: calc(var(--about-hero-word-index, 0) * 65ms);
         display: inline-block;
     }

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -20,10 +20,10 @@ const years = [
     title="Articles - William De Azevedo"
     description="Articles sur le développement front-end, Astro, React, Next.js, TypeScript et mes retours d'expérience en tant que développeur freelance."
 >
-    <div class="mx-auto w-full max-w-5xl px-2 pb-20 sm:px-4">
-        <section class="mx-auto mb-8 max-w-2xl text-center">
+    <div class="mx-auto w-full max-w-[calc(100vw-1rem)] px-2 pb-20 sm:max-w-5xl sm:px-4">
+        <section class="mx-auto mb-8 w-full max-w-[22rem] text-center sm:max-w-2xl">
             <FadeReveal delay={0.1}>
-                <h1 class="mb-4 text-3xl font-medium leading-tight text-gray-900 md:text-5xl">
+                <h1 class="mb-4 text-2xl font-medium leading-tight text-gray-900 sm:text-3xl md:text-5xl">
                     «&nbsp;Enseigner, c'est apprendre deux fois&nbsp;»
                 </h1>
             </FadeReveal>
@@ -98,7 +98,7 @@ const years = [
 
 <style>
     .article-list-item {
-        animation: article-fade-in 520ms cubic-bezier(0.2, 0, 0, 1) both;
+        animation: article-fade-in 520ms cubic-bezier(0.2, 0, 0, 1) backwards;
         animation-delay: calc(var(--article-index, 0) * 70ms);
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -50,16 +50,16 @@ const displayedTestimonials = temoignages
 ---
 
 <Layout>
-    <section class="mx-auto w-full max-w-5xl px-2 sm:px-4">
-        <div class="flex flex-col gap-6">
+    <section class="mx-auto w-full max-w-[calc(100vw-1rem)] px-2 sm:max-w-5xl sm:px-4">
+        <div class="flex min-w-0 flex-col gap-6">
             <p
-                class="mx-auto w-fit max-w-[calc(100vw-1rem)] rounded-xl bg-blue-500 px-4 py-1.5 text-center text-sm font-light leading-none text-snow-50 shadow-[0_10px_18px_-8px_rgba(37,99,235,0.85)] ring-1 ring-blue-400/70 md:text-base"
+                class="mx-auto w-fit max-w-[22rem] rounded-xl bg-blue-500 px-4 py-1.5 text-center text-sm font-light leading-tight text-snow-50 shadow-[0_10px_18px_-8px_rgba(37,99,235,0.85)] ring-1 ring-blue-400/70 md:text-base"
                 data-hero-eyebrow
             >
                 Freelance front-end orienté design et produit
             </p>
             <h1
-                class="flex max-w-full flex-wrap justify-center gap-x-[0.18em] text-center text-5xl font-medium leading-tighter tracking-[-4%] text-gray-900 sm:text-6xl md:text-7xl"
+                class="mx-auto flex w-full max-w-[22rem] flex-wrap justify-center gap-x-[0.18em] px-2 text-center text-4xl font-medium leading-tighter tracking-normal text-gray-900 sm:max-w-4xl sm:text-5xl md:max-w-5xl md:text-7xl"
                 data-animated-title
             >
                 {
@@ -79,7 +79,7 @@ const displayedTestimonials = temoignages
             </h1>
             <FadeReveal delay={0.32}>
                 <p
-                    class="max-w-120 tracking-[-4%] leading-tight text-coffee-300 font-light text-center text-md mx-auto"
+                    class="mx-auto max-w-[22rem] text-center text-md font-light leading-tight tracking-normal text-coffee-300 sm:max-w-120"
                 >
                     J’aide les petites structures et les équipes produit à lancer
                     des interfaces & sites performants, accessibles et
@@ -87,9 +87,9 @@ const displayedTestimonials = temoignages
                 </p>
             </FadeReveal>
             <FadeReveal delay={0.44}>
-                <div class="flex flex-wrap gap-3 items-center justify-center sm:gap-8">
+                <div class="mx-auto flex w-full max-w-[22rem] flex-col items-center justify-center gap-3 sm:max-w-none sm:flex-row sm:gap-8">
                     <button
-                        class="hero-button hero-button--primary font-regular px-5 text-md py-1.5 rounded-xl h-12 flex justify-center items-center sm:px-6"
+                        class="hero-button hero-button--primary font-regular flex h-12 w-full max-w-full items-center justify-center rounded-xl px-5 py-1.5 text-md sm:w-auto sm:px-6"
                         data-cal-location="hero"
                         data-cal-open
                         type="button"
@@ -106,7 +106,7 @@ const displayedTestimonials = temoignages
                         </WaveIcon>
                     </button>
                     <a
-                        class="hero-button hero-button--secondary font-regular px-5 py-1.5 rounded-xl h-12 flex text-md justify-center items-center sm:px-6"
+                        class="hero-button hero-button--secondary font-regular flex h-12 w-full max-w-full items-center justify-center rounded-xl px-5 py-1.5 text-md sm:w-auto sm:px-6"
                         href="#projects"
                         ><WaveText
                             text="Voir mes réalisations"
@@ -445,7 +445,8 @@ const displayedTestimonials = temoignages
 
 <style>
     [data-hero-eyebrow] {
-        animation: hero-eyebrow-fade 780ms cubic-bezier(0.2, 0, 0, 1) both;
+        animation: hero-eyebrow-fade 780ms cubic-bezier(0.2, 0, 0, 1)
+            backwards;
     }
 
     @keyframes hero-eyebrow-fade {
@@ -498,8 +499,8 @@ const displayedTestimonials = temoignages
     .testimonial-rotator__item.is-active .testimonial-avatar,
     .testimonial-rotator__item.is-active figcaption,
     .testimonial-rotator__item.is-active blockquote {
-        animation: testimonial-content-in 920ms
-            cubic-bezier(0.22, 1.16, 0.36, 1) both;
+        animation: testimonial-content-in 920ms cubic-bezier(0.22, 1.16, 0.36, 1)
+            backwards;
     }
 
     .testimonial-rotator__item.is-active .testimonial-avatar {
@@ -587,7 +588,7 @@ const displayedTestimonials = temoignages
     [data-animated-title][data-animated-title-ready="true"]
         [data-animated-title-word] {
         animation: animated-title-word 1100ms cubic-bezier(0.16, 1, 0.3, 1)
-            both;
+            backwards;
         animation-delay: calc(var(--animated-word-index, 0) * 65ms);
     }
 
@@ -663,7 +664,7 @@ const displayedTestimonials = temoignages
     .project-copy__panel[data-project-panel-animate="true"]
         :global(.project-intro__button) {
         animation: project-panel-copy-reveal 760ms
-            cubic-bezier(0.34, 1.2, 0.64, 1) both;
+            cubic-bezier(0.34, 1.2, 0.64, 1) backwards;
     }
 
     .project-copy__panel[data-project-panel-animate="true"]

--- a/src/scripts/animations/fadeIn.ts
+++ b/src/scripts/animations/fadeIn.ts
@@ -1,10 +1,62 @@
 const observerByDocument = new WeakMap<Document, IntersectionObserver>();
 
+function secondsToMs(value: string) {
+  const trimmed = value.trim();
+  if (trimmed.endsWith("ms")) return Number.parseFloat(trimmed);
+  if (trimmed.endsWith("s")) return Number.parseFloat(trimmed) * 1000;
+  return Number.parseFloat(trimmed) || 0;
+}
+
+function getLongestTransitionMs(element: HTMLElement) {
+  const styles = window.getComputedStyle(element);
+  const durations = styles.transitionDuration.split(",").map(secondsToMs);
+  const delays = styles.transitionDelay.split(",").map(secondsToMs);
+  let longest = 0;
+
+  for (let index = 0; index < durations.length; index += 1) {
+    const duration = durations[index] ?? 0;
+    const delay = delays[index] ?? delays.at(-1) ?? 0;
+    longest = Math.max(longest, duration + delay);
+  }
+
+  return longest;
+}
+
+function completeReveal(element: HTMLElement) {
+  element.classList.add("is-reveal-complete");
+}
+
+function revealElement(element: HTMLElement) {
+  element.classList.add("is-visible");
+
+  const longestTransitionMs = getLongestTransitionMs(element);
+
+  if (longestTransitionMs <= 0) {
+    completeReveal(element);
+    return;
+  }
+
+  const timeout = window.setTimeout(
+    () => completeReveal(element),
+    longestTransitionMs + 80
+  );
+
+  element.addEventListener(
+    "transitionend",
+    (event) => {
+      if (event.target !== element) return;
+      window.clearTimeout(timeout);
+      completeReveal(element);
+    },
+    { once: true }
+  );
+}
+
 export function initFadeInAnimations(root: Document) {
   if (!("IntersectionObserver" in window)) {
     root
       .querySelectorAll<HTMLElement>("[data-reveal-on-scroll]")
-      .forEach((element) => element.classList.add("is-visible"));
+      .forEach(revealElement);
     return;
   }
 
@@ -17,7 +69,7 @@ export function initFadeInAnimations(root: Document) {
           if (!entry.isIntersecting) return;
 
           const element = entry.target as HTMLElement;
-          element.classList.add("is-visible");
+          revealElement(element);
           observer?.unobserve(element);
         });
       },


### PR DESCRIPTION
## What
- Preserve reveal blur during the animation while forcing the settled state back to filter: none.
- Add reveal completion handling for scroll reveals so mobile Safari does not keep rasterized blurred text.
- Tighten mobile home/article layout and render explicit article filter labels.

## Validation
- bun run format:check
- bun run lint
- bun run build
- Mobile Chrome/CDP 390x844: checked early blur exists, late state is filter none, article filters render, search empty state works.