### PR TITLE
fix(about): add avatar spacing

### DIFF
--- a/src/components/AboutCallout.astro
+++ b/src/components/AboutCallout.astro
@@ -215,7 +215,8 @@ const aboutPoints = [
             0 4px 14px rgba(0, 0, 0, 0.24);
         display: inline-flex;
         height: 1.08em;
-        margin-inline: -0.05em;
+        margin-inline-end: -0.03em;
+        margin-inline-start: 0.14em;
         overflow: hidden;
     }
 


### PR DESCRIPTION
## Summary
- add breathing room between the William wordmark text and the round portrait avatar in the about callout

## Checks
- bun run format:check
- bun run lint
- bun run build