### PR TITLE
Ajoute un widget de contact flottant

### DIFF
--- a/src/components/FloatingContact.astro
+++ b/src/components/FloatingContact.astro
@@ -1,0 +1,541 @@
+---
+import ArrowUpRight from "./icons/nucleo/arrow-up-right-fill.svg";
+import XMark from "./icons/nucleo/xmark-fill.svg";
+import BrandMark from "./ui/BrandMark.astro";
+---
+
+<div
+    class="floating-contact"
+    data-floating-contact
+    transition:persist="floating-contact"
+>
+    <button
+        aria-controls="floating-contact-panel"
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        aria-label="Parler de votre projet"
+        class="floating-contact__trigger"
+        data-floating-contact-open
+        type="button"
+    >
+        <BrandMark class="floating-contact__mark" />
+    </button>
+
+    <div
+        aria-hidden="true"
+        aria-describedby="floating-contact-description"
+        aria-labelledby="floating-contact-title"
+        class="floating-contact__panel"
+        data-floating-contact-panel
+        id="floating-contact-panel"
+        inert
+        role="dialog"
+    >
+        <section class="floating-contact__intro">
+            <button
+                aria-label="Fermer"
+                class="floating-contact__close"
+                data-floating-contact-close
+                type="button"
+            >
+                <XMark aria-hidden="true" />
+            </button>
+
+            <p class="floating-contact__eyebrow">Premier échange</p>
+            <h2 class="floating-contact__title" id="floating-contact-title">
+                Cadrons votre projet en 15 min
+            </h2>
+            <p
+                class="floating-contact__description"
+                id="floating-contact-description"
+            >
+                Présentez-moi votre besoin : nous ferons le point sur vos
+                objectifs, vos priorités et les prochaines étapes.
+            </p>
+
+            <button
+                aria-controls="cal-drawer"
+                aria-haspopup="dialog"
+                class="floating-contact__primary"
+                data-cal-location="floating-contact"
+                data-cal-open
+                type="button"
+            >
+                <span>Réserver 15 min</span>
+                <ArrowUpRight aria-hidden="true" />
+            </button>
+        </section>
+
+        <section class="floating-contact__alternative">
+            <p class="floating-contact__eyebrow">Vous préférez écrire ?</p>
+            <a
+                class="floating-contact__email"
+                data-analytics-label="E-mail du contact flottant"
+                data-analytics-location="floating-contact"
+                href="mailto:william.deazevedopro@gmail.com"
+            >
+                william.deazevedopro@gmail.com
+            </a>
+            <p class="floating-contact__note">
+                Décrivez-moi votre projet directement par e-mail.
+            </p>
+
+            <div class="floating-contact__actions">
+                <a
+                    class="floating-contact__action"
+                    data-analytics-label="Envoyer un e-mail"
+                    data-analytics-location="floating-contact"
+                    href="mailto:william.deazevedopro@gmail.com"
+                >
+                    Envoyer un e-mail
+                </a>
+                <a
+                    class="floating-contact__action floating-contact__action--quiet"
+                    href="/tarifs/"
+                >
+                    Voir les tarifs
+                </a>
+            </div>
+        </section>
+    </div>
+</div>
+
+<script>
+    import { trackAnalytics } from "../scripts/analytics";
+
+    const widget = document.querySelector("[data-floating-contact]");
+    const panel = document.querySelector("[data-floating-contact-panel]");
+    const trigger = widget?.querySelector("[data-floating-contact-open]");
+    const closeButton = widget?.querySelector("[data-floating-contact-close]");
+
+    if (
+        widget instanceof HTMLElement &&
+        panel instanceof HTMLElement &&
+        trigger instanceof HTMLButtonElement &&
+        closeButton instanceof HTMLButtonElement
+    ) {
+        const isOpen = () => widget.classList.contains("is-open");
+
+        const openPanel = () => {
+            if (isOpen()) return;
+
+            widget.classList.add("is-open");
+            panel.inert = false;
+            panel.setAttribute("aria-hidden", "false");
+            trigger.setAttribute("aria-expanded", "true");
+            trigger.tabIndex = -1;
+
+            window.requestAnimationFrame(() => closeButton.focus());
+
+            trackAnalytics("floating_contact_open", {
+                path: window.location.pathname || "/",
+            });
+        };
+
+        const closePanel = ({ restoreFocus = true } = {}) => {
+            if (!isOpen()) return;
+
+            widget.classList.remove("is-open");
+            panel.inert = true;
+            panel.setAttribute("aria-hidden", "true");
+            trigger.setAttribute("aria-expanded", "false");
+            trigger.tabIndex = 0;
+
+            if (restoreFocus) {
+                window.requestAnimationFrame(() =>
+                    trigger.focus({ preventScroll: true }),
+                );
+            }
+
+            trackAnalytics("floating_contact_close", {
+                path: window.location.pathname || "/",
+            });
+        };
+
+        trigger.addEventListener("click", openPanel);
+        closeButton.addEventListener("click", () => closePanel());
+
+        panel.addEventListener("click", (event) => {
+            const target = event.target;
+            if (!(target instanceof Element)) return;
+
+            if (
+                target.closest("a[href]") ||
+                target.closest("[data-cal-open]")
+            ) {
+                closePanel({ restoreFocus: false });
+            }
+        });
+
+        document.addEventListener(
+            "pointerdown",
+            (event) => {
+                const target = event.target;
+                if (
+                    !isOpen() ||
+                    !(target instanceof Node) ||
+                    panel.contains(target) ||
+                    trigger.contains(target)
+                ) {
+                    return;
+                }
+
+                closePanel({ restoreFocus: false });
+            },
+            { capture: true },
+        );
+
+        document.addEventListener("keydown", (event) => {
+            if (!isOpen() || event.key !== "Escape") return;
+
+            event.preventDefault();
+            closePanel();
+        });
+
+        document.addEventListener("astro:before-swap", () =>
+            closePanel({ restoreFocus: false }),
+        );
+    }
+</script>
+
+<style>
+    .floating-contact {
+        bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+        position: fixed;
+        right: calc(1.25rem + env(safe-area-inset-right, 0px));
+        z-index: 70;
+    }
+
+    .floating-contact__trigger {
+        align-items: center;
+        background: var(--color-blue-50);
+        border: 1px solid color-mix(in srgb, var(--color-blue-500) 20%, white);
+        border-radius: 999px;
+        box-shadow:
+            0 1rem 2.5rem -1.15rem rgba(31, 38, 52, 0.42),
+            inset 0 1px rgba(255, 255, 255, 0.9);
+        color: var(--color-blue-500);
+        cursor: pointer;
+        display: inline-flex;
+        height: 3.5rem;
+        justify-content: center;
+        padding: 0;
+        position: relative;
+        transition:
+            background-color 260ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1)),
+            box-shadow 260ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1)),
+            color 260ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1)),
+            opacity 220ms ease,
+            transform 420ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1));
+        width: 3.5rem;
+    }
+
+    .floating-contact.is-open .floating-contact__trigger {
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(0.35rem) scale(0.88);
+    }
+
+    .floating-contact__trigger::after {
+        border: 1px solid color-mix(in srgb, var(--color-blue-500) 24%, transparent);
+        border-radius: inherit;
+        content: "";
+        inset: -0.28rem;
+        opacity: 0;
+        pointer-events: none;
+        position: absolute;
+        transform: scale(0.92);
+        transition:
+            opacity 260ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1)),
+            transform 420ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1));
+    }
+
+    .floating-contact__trigger:focus-visible {
+        outline: 2px solid var(--color-blue-500);
+        outline-offset: 4px;
+    }
+
+    .floating-contact__mark {
+        height: auto;
+        width: 1.75rem;
+    }
+
+    .floating-contact__panel {
+        background: var(--color-snow-50);
+        border: 0;
+        border-radius: 1rem;
+        bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+        box-shadow: 0 1.5rem 3.5rem -1.25rem rgba(31, 38, 52, 0.38);
+        color: var(--color-gray-900);
+        left: auto;
+        margin: 0;
+        max-height: calc(
+            100dvh - 2.5rem - env(safe-area-inset-top, 0px) -
+                env(safe-area-inset-bottom, 0px)
+        );
+        max-width: none;
+        opacity: 0;
+        overflow: auto;
+        padding: 0;
+        pointer-events: none;
+        position: fixed;
+        right: calc(1.25rem + env(safe-area-inset-right, 0px));
+        top: auto;
+        transform: translateY(0.75rem) scale(0.975);
+        transform-origin: bottom right;
+        transition:
+            opacity 220ms ease,
+            transform 420ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1)),
+            visibility 0s linear 420ms;
+        visibility: hidden;
+        width: min(25rem, calc(100dvw - 2.5rem));
+    }
+
+    .floating-contact.is-open .floating-contact__panel {
+        opacity: 1;
+        pointer-events: auto;
+        transform: none;
+        transition-delay: 0s;
+        visibility: visible;
+    }
+
+    .floating-contact__intro,
+    .floating-contact__alternative {
+        background: var(--color-snow-50);
+    }
+
+    .floating-contact__intro {
+        border-left: 0.375rem solid var(--color-blue-500);
+        border-radius: 1rem 1rem 0 0;
+        padding: 1.75rem 4.25rem 1.75rem 1.75rem;
+        position: relative;
+    }
+
+    .floating-contact__alternative {
+        border-radius: 0 0 1rem 1rem;
+        border-top: 1px solid var(--color-snow-600);
+        padding: 1.5rem 1.75rem 1.75rem 2.125rem;
+    }
+
+    .floating-contact__close {
+        align-items: center;
+        background: transparent;
+        border: 0;
+        border-radius: 0.65rem;
+        color: var(--color-gray-600);
+        cursor: pointer;
+        display: inline-flex;
+        height: 2.75rem;
+        justify-content: center;
+        padding: 0;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.75rem;
+        transition:
+            background-color 220ms ease,
+            color 220ms ease,
+            transform 320ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1));
+        width: 2.75rem;
+    }
+
+    .floating-contact__close:focus-visible,
+    .floating-contact__primary:focus-visible,
+    .floating-contact__action:focus-visible,
+    .floating-contact__email:focus-visible {
+        outline: 2px solid var(--color-blue-500);
+        outline-offset: 3px;
+    }
+
+    .floating-contact__eyebrow {
+        color: var(--color-blue-700);
+        font-size: 0.72rem;
+        font-weight: 600;
+        letter-spacing: 0.14em;
+        line-height: 1.2;
+        margin: 0 0 0.75rem;
+        text-transform: uppercase;
+    }
+
+    .floating-contact__title {
+        color: var(--color-coffee-300);
+        font-size: clamp(1.65rem, 5vw, 2rem);
+        font-weight: 600;
+        letter-spacing: -0.045em;
+        line-height: 1.08;
+        margin: 0;
+        text-wrap: balance;
+    }
+
+    .floating-contact__description {
+        color: var(--color-gray-700);
+        font-size: 0.95rem;
+        line-height: 1.55;
+        margin: 0.85rem 0 1.25rem;
+        max-width: 31ch;
+    }
+
+    .floating-contact__primary {
+        align-items: center;
+        background: var(--color-blue-500);
+        border: 1px solid var(--color-blue-500);
+        border-radius: 0.75rem;
+        color: var(--color-snow-50);
+        cursor: pointer;
+        display: inline-flex;
+        font-size: 0.9rem;
+        font-weight: 600;
+        gap: 0.75rem;
+        justify-content: center;
+        min-height: 3rem;
+        padding: 0.75rem 1.15rem;
+        transition:
+            background-color 220ms ease,
+            border-color 220ms ease,
+            transform 360ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1));
+    }
+
+    .floating-contact__email {
+        color: var(--color-coffee-300);
+        display: inline-block;
+        font-size: clamp(1rem, 3.5vw, 1.15rem);
+        font-weight: 600;
+        line-height: 1.3;
+        overflow-wrap: anywhere;
+        text-decoration: none;
+        text-underline-offset: 0.2em;
+    }
+
+    .floating-contact__note {
+        color: var(--color-gray-600);
+        font-size: 0.82rem;
+        line-height: 1.45;
+        margin: 0.35rem 0 1rem;
+    }
+
+    .floating-contact__actions {
+        display: grid;
+        gap: 0.55rem;
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .floating-contact__action {
+        align-items: center;
+        background: var(--color-snow-50);
+        border: 1px solid var(--color-gray-400);
+        border-radius: 0.65rem;
+        color: var(--color-coffee-300);
+        display: inline-flex;
+        font-size: 0.82rem;
+        font-weight: 600;
+        justify-content: center;
+        min-height: 2.75rem;
+        padding: 0.65rem 0.8rem;
+        text-align: center;
+        text-decoration: none;
+        transition:
+            background-color 220ms ease,
+            border-color 220ms ease,
+            color 220ms ease,
+            transform 360ms
+                var(--wui-ease-standard, cubic-bezier(0.2, 0, 0, 1));
+    }
+
+    .floating-contact__action--quiet {
+        background: var(--color-snow-200);
+    }
+
+    @media (hover: hover) {
+        .floating-contact__trigger:hover {
+            background: var(--color-blue-500);
+            box-shadow: 0 1.15rem 2.75rem -1.1rem rgba(62, 96, 212, 0.58);
+            color: var(--color-snow-50);
+            transform: translateY(-0.2rem);
+        }
+
+        .floating-contact__trigger:hover::after {
+            opacity: 1;
+            transform: scale(1);
+        }
+
+        .floating-contact__close:hover {
+            background: var(--color-snow-200);
+            color: var(--color-coffee-300);
+            transform: rotate(4deg);
+        }
+
+        .floating-contact__primary:hover {
+            background: var(--color-blue-600);
+            border-color: var(--color-blue-600);
+            transform: translateY(-0.1rem);
+        }
+
+        .floating-contact__email:hover {
+            text-decoration: underline;
+        }
+
+        .floating-contact__action:hover {
+            background: var(--color-blue-50);
+            border-color: var(--color-blue-200);
+            color: var(--color-blue-700);
+            transform: translateY(-0.08rem);
+        }
+    }
+
+    @media (max-width: 479px) {
+        .floating-contact {
+            bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+            right: calc(0.75rem + env(safe-area-inset-right, 0px));
+        }
+
+        .floating-contact__panel {
+            bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+            left: calc(0.5rem + env(safe-area-inset-left, 0px));
+            max-height: calc(
+                100dvh - 1rem - env(safe-area-inset-top, 0px) -
+                    env(safe-area-inset-bottom, 0px)
+            );
+            right: calc(0.5rem + env(safe-area-inset-right, 0px));
+            width: auto;
+        }
+
+        .floating-contact__intro {
+            padding: 1.5rem 3.75rem 1.5rem 1.25rem;
+        }
+
+        .floating-contact__alternative {
+            padding: 1.25rem;
+        }
+    }
+
+    @media (max-width: 349px) {
+        .floating-contact__actions {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .floating-contact__trigger,
+        .floating-contact__trigger::after,
+        .floating-contact__panel,
+        .floating-contact__close,
+        .floating-contact__primary,
+        .floating-contact__action {
+            transition: none;
+        }
+    }
+
+    @media print {
+        .floating-contact {
+            display: none;
+        }
+    }
+</style>

--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -1,8 +1,9 @@
 ---
 import { ClientRouter } from "astro:transitions";
+import CalDrawer from "../components/CalDrawer.astro";
+import FloatingContact from "../components/FloatingContact.astro";
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
-import CalDrawer from "../components/CalDrawer.astro";
 import "../styles/global.css";
 
 interface Props {
@@ -163,6 +164,7 @@ const personJsonLd = {
             <slot />
         </main>
         <Footer />
+        <FloatingContact />
         <CalDrawer />
         <script>
             import {

--- a/src/scripts/mobileFooterBoundary.ts
+++ b/src/scripts/mobileFooterBoundary.ts
@@ -16,7 +16,8 @@ const isOverlayInteraction = (target: EventTarget | null) =>
   target instanceof Element &&
   Boolean(
     target.closest("dialog[open]") ||
-    target.closest("[data-mobile-menu]:not([hidden])")
+    target.closest("[data-mobile-menu]:not([hidden])") ||
+    target.closest("[data-floating-contact-panel][aria-hidden='false']")
   );
 
 const getViewportMetrics = () => {


### PR DESCRIPTION
## Pourquoi

Ajouter un point de contact discret et permanent, inspiré de la référence fournie, sans alourdir la stack Astro existante ni dupliquer le parcours de réservation.

## Ce qui change

- ajoute un bouton flottant aux couleurs de la marque avec le logo existant ;
- ouvre un panneau compact en deux parties pour réserver 15 min, envoyer un e-mail ou consulter les tarifs ;
- réutilise le tiroir Cal.com et le suivi analytics déjà présents ;
- gère Échap, clic extérieur, retour du focus, états ARIA et réduction des animations ;
- persiste correctement avec le `ClientRouter` Astro ;
- s’adapte aux petits écrans, aux zones sûres mobiles et au scroll tactile du panneau.

## Validation

- `bun run lint`
- `bun astro build`
- vérification navigateur desktop et mobile (390 × 844 et 320 × 568)
- ouverture/fermeture, clic extérieur, Échap, passage vers Cal.com et navigation vers `/tarifs/`
